### PR TITLE
sky: avoid drawing normal clouds when blocky enabled

### DIFF
--- a/shaders/include/sky/sky.glsl
+++ b/shaders/include/sky/sky.glsl
@@ -99,7 +99,11 @@ vec4 get_clouds_and_aurora(vec3 ray_dir, vec3 clear_sky) {
 	float dither = interleaved_gradient_noise(vec2(texel));
 
 	// Render clouds
+#ifdef BLOCKY_CLOUDS
+	vec4 clouds = vec4(0.0, 0.0, 0.0, 1.0);
+#else
 	vec4 clouds = draw_clouds(ray_dir, clear_sky, dither);
+#endif
 
 	// Render aurora
 	vec3 aurora = draw_aurora(ray_dir, dither);


### PR DESCRIPTION
This partially fixes #73. A full fix is a bit more involved, I'll have a look at it later.