### PR TITLE
Handheld lighting fix for coordinates beyond 30k.

### DIFF
--- a/shaders/include/light/handheld_lighting.glsl
+++ b/shaders/include/light/handheld_lighting.glsl
@@ -6,7 +6,7 @@ uniform sampler2D light_data_sampler;
 #endif
 
 #ifdef IS_IRIS
-uniform vec3 eyePosition;
+uniform vec3 relativeEyePosition;
 #endif
 
 uniform int heldItemId;
@@ -36,7 +36,7 @@ float get_handheld_light_falloff(vec3 scene_pos, float ao) {
 vec3 get_handheld_lighting(vec3 scene_pos, float ao) {
 #ifdef IS_IRIS
 	// Center light on player rather than camera
-	scene_pos += cameraPosition - eyePosition;
+	scene_pos += relativeEyePosition;
 #endif
 
 	vec3 light_color = max(


### PR DESCRIPTION
Updated handheld_lighting.glsl to use new (Nov 4, 2023) relativeEyePosition uniform. Tsumi technically fixed this by getting Iris to incorporate the new relativeEyePosition uniform, but it seems the fix wasn't integrated into photon, not on GitHub at least. Thought I'd give a go at integrating it with zero code knowledge, I succeeded apparently.