### PR TITLE
Fix roughness threshold

### DIFF
--- a/shaders/include/light/specular_lighting.glsl
+++ b/shaders/include/light/specular_lighting.glsl
@@ -252,11 +252,12 @@ vec3 get_specular_reflections(
 	float alpha_squared = sqr(material.roughness);
 
 	float dither = r1(frameCounter, texelFetch(noisetex, ivec2(gl_FragCoord.xy) & 511, 0).b);
+
 	float roughness_threshold;
-	if (material.is_hardcoded_metal || material.is_metal) {
-		roughness_threshold = 0.0;
-	} else {
+	if (max_of(material.albedo) < eps) {
 		roughness_threshold = 5e-2;
+	} else {
+		roughness_threshold = 0.0;
 	}
 
 #if defined SSR_ROUGHNESS_SUPPORT && defined SPECULAR_MAPPING
@@ -272,7 +273,7 @@ vec3 get_specular_reflections(
 
 			vec2 smoothness_mapping;
 			if (material.roughness < 5e-2) {
-				smoothness_mapping = pow(vec2(material.roughness), vec2(1 - material.roughness));
+				smoothness_mapping = pow(vec2(material.roughness), vec2(1.1 - material.roughness));
 			} else {
 				smoothness_mapping = vec2(material.roughness);
 			}

--- a/shaders/include/light/specular_lighting.glsl
+++ b/shaders/include/light/specular_lighting.glsl
@@ -292,9 +292,9 @@ vec3 get_specular_reflections(
 
 			vec3 fresnel;
 			if (material.is_hardcoded_metal) {
-				fresnel = sqr(fresnel_lazanyi_2019(NoV, material.f0, material.f82));
+				fresnel = fresnel_lazanyi_2019(NoV, material.f0, material.f82);
 			} else if (material.is_metal) {
-				fresnel = sqr(fresnel_schlick(NoV, material.albedo));
+				fresnel = fresnel_schlick(NoV, material.albedo);
 			} else {
 				fresnel = fresnel_dielectric(NoV, material.f0.x);
 			}

--- a/shaders/include/light/specular_lighting.glsl
+++ b/shaders/include/light/specular_lighting.glsl
@@ -279,8 +279,8 @@ vec3 get_specular_reflections(
 			}
 
 			vec3 microfacet_normal = tbn_matrix * sample_ggx_vndf(-tangent_dir, smoothness_mapping, hash);
-			vec3 ray_dir = reflect(world_dir, microfacet_normal);
-				ray_dir += reflect(world_dir * 0.25, normal);
+			vec3 ray_dir = reflect(world_dir * 0.5, microfacet_normal);
+				ray_dir += reflect(world_dir * 0.5, normal);
 
 			float NoL = dot(normal, ray_dir);
 			if (NoL < eps) continue;
@@ -292,9 +292,9 @@ vec3 get_specular_reflections(
 
 			vec3 fresnel;
 			if (material.is_hardcoded_metal) {
-				fresnel = fresnel_lazanyi_2019(NoV, material.f0, material.f82);
+				fresnel = sqr(fresnel_lazanyi_2019(NoV, material.f0, material.f82));
 			} else if (material.is_metal) {
-				fresnel = fresnel_schlick(NoV, material.albedo);
+				fresnel = sqr(fresnel_schlick(NoV, material.albedo));
 			} else {
 				fresnel = fresnel_dielectric(NoV, material.f0.x);
 			}
@@ -302,7 +302,7 @@ vec3 get_specular_reflections(
 			float v1 = v1_smith_ggx(NoV, alpha_squared);
 			float v2 = v2_smith_ggx(NoL, NoV, alpha_squared);
 
-			reflection += radiance * fresnel * (2.0 * NoL * v2 / v1);
+			reflection += radiance * albedo_tint * fresnel * (2.0 * NoL * v2 / v1);
 		}
 
 		reflection *= albedo_tint * rcp(float(SSR_RAY_COUNT));


### PR DESCRIPTION
This PR closes https://github.com/sixthsurge/photon/issues/72

Removed mirror-like reflections on blocks and opted to make rough reflections cover smooth reflections as well.

| | Before | After |
| ------------- | ------------- | ------------- |
| VNR | ![VNR-0](https://github.com/sixthsurge/photon/assets/70870719/fd13d324-4ad5-4f5a-beed-4c1dd00d39b8) | ![VNR-1](https://github.com/sixthsurge/photon/assets/70870719/190707d3-2d75-4023-ba24-690eee0edb13) |
| AVPBR x16 | ![AVPBR-0](https://github.com/sixthsurge/photon/assets/70870719/0752a7ef-2487-4937-979c-9ff0ce34ed07) | ![AVPBR-1](https://github.com/sixthsurge/photon/assets/70870719/7fa6ae04-eb86-419f-b6b9-a3e1aa34a35c) |
| Embrace Pixels | ![EP-0](https://github.com/sixthsurge/photon/assets/70870719/388629bd-783f-4651-bf7a-53c114cb1a41) | ![EP-1](https://github.com/sixthsurge/photon/assets/70870719/7ce0c026-0434-4378-998e-7428978f49f4) |
| PNA PBR | ![PNA-0](https://github.com/sixthsurge/photon/assets/70870719/863ae4b9-cba2-4ba0-94bd-8f1bc4d26ffa) | ![PNA-1](https://github.com/sixthsurge/photon/assets/70870719/d223a360-e2c5-4fb1-bb5d-cfc079427e0b) |
| Simplista | ![Simp-0](https://github.com/sixthsurge/photon/assets/70870719/52184112-bc14-4262-b185-02b29dcbd00b) | ![Simp-1](https://github.com/sixthsurge/photon/assets/70870719/e828049e-5a6b-4ef7-be71-50a306385a8a) |

*All screenshots are with roughness threshold set to 2*