### PR TITLE
Fix Uncharted 2 tonemap

### DIFF
--- a/shaders/program/post/grade.glsl
+++ b/shaders/program/post/grade.glsl
@@ -253,16 +253,24 @@ vec3 tonemap_lottes(vec3 rgb) {
 }
 
 // Filmic tonemapping operator made by John Hable for Uncharted 2
-vec3 tonemap_uncharted_2(vec3 rgb) {
+vec3 tonemap_uncharted_2_partial(vec3 rgb) {
 	const float a = 0.15;
 	const float b = 0.50;
 	const float c = 0.10;
 	const float d = 0.20;
 	const float e = 0.02;
 	const float f = 0.30;
-	const float w = 11.2;
 
 	return ((rgb * (a * rgb + (c * b)) + (d * e)) / (rgb * (a * rgb + b) + d * f)) - e / f;
+}
+
+vec3 tonemap_uncharted_2(vec3 rgb) {
+	const float exposure_bias = 2.0;
+	const vec3 w = vec3(11.2);
+
+	vec3 curr = tonemap_uncharted_2_partial(rgb * exposure_bias);
+	vec3 white_scale = vec3(1.0) / tonemap_uncharted_2_partial(w);
+	return curr * white_scale;
 }
 
 // Tone mapping operator made by Tech for his shader pack Lux


### PR DESCRIPTION
This fixes the Uncharted 2 tonemap in photon being too dark. It was using a partial equation instead of the full equation from [filmicworlds.com/blog/filmic-tonemapping-operators](http://filmicworlds.com/blog/filmic-tonemapping-operators/).

Before                 |  After
:------------------:|:------------------:
![Before 0][old_0] | ![After 0][new_0]
![Before 1][old_1] | ![After 1][new_1]

The difference is also visible in bright colors and contrast
Before (Adjusted Exposure) |  After
:------------------:|:------------------:
![Before 2][old_adjust_2] | ![After 2][new_2]

[old_0]: https://github.com/sixthsurge/photon/assets/79641713/9ff76bb6-f9d1-4de5-9719-7d122c1962ab
[new_0]: https://github.com/sixthsurge/photon/assets/79641713/2563c0b1-0e4d-4517-b6cb-7f97e964c6c0
[old_1]: https://github.com/sixthsurge/photon/assets/79641713/770264ce-d186-45c2-b6b8-4afdcdd57352
[new_1]: https://github.com/sixthsurge/photon/assets/79641713/25a6bf00-788a-4b42-a03d-7a7cb2914a07
[old_adjust_2]: https://github.com/sixthsurge/photon/assets/79641713/4dc8d305-1e37-4dc3-ab24-908ef6d76913
[new_2]: https://github.com/sixthsurge/photon/assets/79641713/642027e4-647a-4d1c-aacf-a1448ff6d205