### PR TITLE
Fix moonlight color inheritance on vanilla moon's texture

### DIFF
--- a/shaders/program/gbuffer/skytextured.glsl
+++ b/shaders/program/gbuffer/skytextured.glsl
@@ -101,7 +101,7 @@ void main() {
 		if (max_of(abs(offset)) > 0.25) discard;
 		*/
 
-		scene_color.rgb = texture(gtexture, new_uv).rgb;
+		scene_color.rgb = texture(gtexture, new_uv).rgb * vec3(MOON_R, MOON_G, MOON_B);
 
 		break;
 #else


### PR DESCRIPTION
Small fix that heavily improves the night sky if using custom moonlight colors

## Example using a moonlight color of 1.00, 0.88, 0.65

- Before fix:
![2024-06-20_09 29 45](https://github.com/sixthsurge/photon/assets/105564560/3a5641a8-8fcf-487c-a73f-bcd86b6167d5)

- After fix:
![2024-06-20_09 30 49](https://github.com/sixthsurge/photon/assets/105564560/5e69ccb3-19e3-4d8f-b7d8-ae89baeaf1a0)
