### PR TITLE
Vivecraft + DH compatibility. Fixes #305.

### DIFF
--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -508,15 +508,15 @@ uniform.float.biome_may_sandstorm = smooth(if(biome_category == CAT_DESERT || bi
 
 variable.float.fov = 2.0 * atan(1.0 / (gbufferProjection.0.0 * aspectRatio))
 
-uniform.float.combined_near = 0.05
+uniform.float.combined_near = near
 uniform.float.combined_far = dhRenderDistance
-uniform.vec4.combined_projection_matrix_0 = vec4(1.0 / (tan(fov / 2.0) * aspectRatio), 0.0, 0.0, 0.0)
-uniform.vec4.combined_projection_matrix_1 = vec4(0.0, 1.0 / tan(fov / 2), 0.0, 0.0)
-uniform.vec4.combined_projection_matrix_2 = vec4(0.0, 0.0, (combined_far + combined_near) / (combined_near - combined_far), -1.0)
+uniform.vec4.combined_projection_matrix_0 = vec4(gbufferProjection.0.0, 0.0, 0.0, 0.0)
+uniform.vec4.combined_projection_matrix_1 = vec4(0.0, gbufferProjection.1.1, 0.0, 0.0)
+uniform.vec4.combined_projection_matrix_2 = vec4(gbufferProjection.2.0, gbufferProjection.2.1, (combined_far + combined_near) / (combined_near - combined_far), -1.0)
 uniform.vec4.combined_projection_matrix_3 = vec4(0.0, 0.0, (2.0 * combined_far * combined_near) / (combined_near - combined_far), 0.0)
 
-uniform.vec4.combined_projection_matrix_inverse_0 = vec4(aspectRatio * tan(fov / 2.0), 0.0, 0.0, 0.0)
-uniform.vec4.combined_projection_matrix_inverse_1 = vec4(0.0, tan(fov / 2.0), 0.0, 0.0)
+uniform.vec4.combined_projection_matrix_inverse_0 = vec4(gbufferProjectionInverse.0.0, 0.0, 0.0, 0.0)
+uniform.vec4.combined_projection_matrix_inverse_1 = vec4(0.0, gbufferProjectionInverse.1.1, 0.0, 0.0)
 uniform.vec4.combined_projection_matrix_inverse_2 = vec4(0.0, 0.0, 0.0, -(combined_far - combined_near) / (2.0 * combined_far * combined_near))
-uniform.vec4.combined_projection_matrix_inverse_3 = vec4(0.0, 0.0, -1.0, (combined_far + combined_near) / (2.0 * combined_far * combined_near))
+uniform.vec4.combined_projection_matrix_inverse_3 = vec4(gbufferProjectionInverse.3.0, gbufferProjectionInverse.3.1, -1.0, (combined_far + combined_near) / (2.0 * combined_far * combined_near))
 #endif


### PR DESCRIPTION
Patch was written by a Vivecraft developer. This solves the issues regarding skewed projection matrices when using both DH and Photon together.

Before state can be seen in #305. Below is a video showcasing correct behavior produced by this patch.

https://github.com/user-attachments/assets/7ad116be-5dbf-4920-bb38-0c03d7c06b89

