### PR TITLE
Add phase function blending for moon phases

### DIFF
--- a/shaders/program/c0_vl.fsh
+++ b/shaders/program/c0_vl.fsh
@@ -105,6 +105,8 @@ uniform float time_noon;
 uniform float time_sunset;
 uniform float time_midnight;
 
+uniform int moonPhase;
+
 // ------------
 //   Includes
 // ------------

--- a/shaders/program/c0_vl.vsh
+++ b/shaders/program/c0_vl.vsh
@@ -58,6 +58,8 @@ uniform float time_midnight;
 
 uniform float desert_sandstorm;
 
+uniform int moonPhase;
+
 #if defined WORLD_OVERWORLD
 #include "/include/sky/projection.glsl"
 #include "/include/weather/fog.glsl"

--- a/shaders/program/d0_sky_map.fsh
+++ b/shaders/program/d0_sky_map.fsh
@@ -107,6 +107,8 @@ uniform float time_midnight;
 uniform float biome_cave;
 uniform float biome_may_snow;
 
+uniform int moonPhase;
+
 // ------------
 //   Includes
 // ------------

--- a/shaders/program/d0_sky_map.vsh
+++ b/shaders/program/d0_sky_map.vsh
@@ -81,6 +81,8 @@ uniform float biome_humidity;
 
 uniform float desert_sandstorm;
 
+uniform int moonPhase;
+
 // ------------
 //   Includes
 // ------------

--- a/shaders/program/d1_clouds.fsh
+++ b/shaders/program/d1_clouds.fsh
@@ -98,6 +98,8 @@ uniform float biome_may_snow;
 uniform float biome_temperature;
 uniform float biome_humidity;
 
+uniform int moonPhase;
+
 // ------------
 //   Includes
 // ------------

--- a/shaders/program/d1_clouds.vsh
+++ b/shaders/program/d1_clouds.vsh
@@ -68,6 +68,8 @@ uniform float biome_humidity;
 
 uniform float desert_sandstorm;
 
+uniform int moonPhase;
+
 // ------------
 //   Includes
 // ------------

--- a/shaders/program/gbuffers_skytextured.vsh
+++ b/shaders/program/gbuffers_skytextured.vsh
@@ -36,13 +36,15 @@ uniform float time_noon;
 uniform float time_sunset;
 uniform float time_midnight;
 
+uniform int moonPhase;
+
 #include "/include/lighting/colors/light_color.glsl"
 
 void main() {
 	sun_color = get_sun_exposure() * get_sun_tint();
 	moon_color = get_moon_exposure() * get_moon_tint();
 
-	uv   = mat2(gl_TextureMatrix[0]) * gl_MultiTexCoord0.xy + gl_TextureMatrix[0][3].xy;
+	uv = mat2(gl_TextureMatrix[0]) * gl_MultiTexCoord0.xy + gl_TextureMatrix[0][3].xy;
 	tint = gl_Color.rgb;
 
 	view_pos = transform(gl_ModelViewMatrix, gl_Vertex.xyz);

--- a/shaders/program/gbuffers_weather.fsh
+++ b/shaders/program/gbuffers_weather.fsh
@@ -34,6 +34,8 @@ uniform vec2 view_pixel_size;
 
 uniform float biome_may_snow;
 
+uniform int moonPhase;
+
 #include "/include/lighting/colors/weather_color.glsl"
 #include "/include/utility/encoding.glsl"
 

--- a/shaders/program/gbuffers_weather.vsh
+++ b/shaders/program/gbuffers_weather.vsh
@@ -29,6 +29,8 @@ uniform int frameCounter;
 uniform vec2 taa_offset;
 uniform vec2 view_pixel_size;
 
+uniform int moonPhase;
+
 void main() {
 	uv = mat2(gl_TextureMatrix[0]) * gl_MultiTexCoord0.xy + gl_TextureMatrix[0][3].xy;
 

--- a/shaders/program/p0_clouds_prep.fsh
+++ b/shaders/program/p0_clouds_prep.fsh
@@ -77,6 +77,8 @@ uniform float time_midnight;
 uniform float biome_cave;
 uniform float biome_may_snow;
 
+uniform int moonPhase;
+
 const vec3 sun_color  = vec3(0.0);
 const vec3 moon_color = vec3(0.0);
 const vec3 sky_color  = vec3(0.0);

--- a/shaders/program/p0_clouds_prep.vsh
+++ b/shaders/program/p0_clouds_prep.vsh
@@ -62,6 +62,7 @@ uniform float biome_humidity;
 
 uniform float desert_sandstorm;
 
+uniform int moonPhase;
 
 #include "/include/weather/clouds.glsl"
 


### PR DESCRIPTION
Blends between atmosphere phase functions depending on the moon phase. This solves certain phases having an unnatural "glow" and creates a more dynamic atmosphere.

<img width="3440" height="1440" alt="2025-09-04_01 28 06" src="https://github.com/user-attachments/assets/cf70083b-6973-4c2c-b647-114cdaf5855c" />
<img width="3440" height="1440" alt="2025-09-04_01 28 13" src="https://github.com/user-attachments/assets/9fdd72f6-fd4d-46e6-866d-f2f5b1d77dd3" />
<img width="3440" height="1440" alt="2025-09-04_01 28 18" src="https://github.com/user-attachments/assets/1ab8640e-e8cb-4d30-b83f-b06cd49c713c" />
<img width="3440" height="1440" alt="2025-09-04_01 28 22" src="https://github.com/user-attachments/assets/5dde53c1-2558-4eb8-bfaa-183c8897c33c" />
<img width="3440" height="1440" alt="2025-09-04_01 28 26" src="https://github.com/user-attachments/assets/2e2ec653-2ffe-4ab8-b5f4-b20c7cd671b8" />
<img width="3440" height="1440" alt="2025-09-04_01 28 30" src="https://github.com/user-attachments/assets/c50dbe1c-0fba-4486-b4fc-f9d613538de1" />
<img width="3440" height="1440" alt="2025-09-04_01 28 33" src="https://github.com/user-attachments/assets/cb6a0638-3cad-4aac-9e6e-378cf52cdd14" />
<img width="3440" height="1440" alt="2025-09-04_01 28 37" src="https://github.com/user-attachments/assets/f72def05-16e0-4b00-b20c-17220b47cfa7" />
