### PR TITLE
Fix SH Skylight Crash On Win Intel

### DIFF
--- a/shaders/include/utility/spherical_harmonics_fallback.glsl
+++ b/shaders/include/utility/spherical_harmonics_fallback.glsl
@@ -1,0 +1,114 @@
+#if !defined INCLUDE_UTILITY_SPHERICAL_HARMONICS
+#define INCLUDE_UTILITY_SPHERICAL_HARMONICS
+
+// Intel just can't handle arrays (as parameters or returned values) properly.
+// Provide a fallback implementation using mat/vec types and structs.
+vec4 sh_coeff_order_1(vec3 direction) {
+	float x = direction.x;
+	float y = direction.y;
+	float z = direction.z;
+
+	return vec4(
+		0.2820947918,
+		0.4886025119 * x,
+		0.4886025119 * z,
+		0.4886025119 * y
+	);
+}
+
+mat3 sh_coeff_order_2(vec3 direction) {
+	float x = direction.x;
+	float y = direction.y;
+	float z = direction.z;
+
+	return mat3(
+		0.2820947918, 0.4886025119 * x, 0.4886025119 * z,
+        0.4886025119 * y, 1.0925484310 * x * y, 1.0925484310 * y * z,
+		0.3153915653 * (3.0 * z * z - 1.0), 0.7725484040 * x * z, 0.3862742020 * (x * x - y * y)
+	);
+}
+
+vec3 sh_evaluate(mat4x3 f, vec3 direction) {
+	vec4 coeff = sh_coeff_order_1(direction);
+
+	return coeff.x * f[0]
+	     + coeff.y * f[1]
+	     + coeff.z * f[2]
+	     + coeff.w * f[3];
+}
+
+struct sh3 {
+	mat3 f1;
+	mat3 f2;
+	mat3 f3;
+};
+
+vec3 sh_evaluate(sh3 f, vec3 direction) {
+	mat3 coeff = sh_coeff_order_2(direction);
+
+	return coeff[0].x * f.f1[0]
+	     + coeff[0].y * f.f1[1]
+	     + coeff[0].z * f.f1[2]
+	     + coeff[1].x * f.f2[0]
+	     + coeff[1].y * f.f2[1]
+	     + coeff[1].z * f.f2[2]
+	     + coeff[2].x * f.f3[0]
+	     + coeff[2].y * f.f3[1]
+	     + coeff[2].z * f.f3[2];
+}
+
+// Convolve SH using circularly symmetric kernel
+sh3 sh_convolve(sh3 f, vec3 kernel) {
+	const vec3 k = sqrt(4.0 * pi / vec3(1.0, 3.0, 5.0));
+
+	vec3 mul = k * kernel;
+
+    sh3 result;
+    result.f1 = mat3(
+		f.f1[0] * mul.x,
+		f.f1[1] * mul.y,
+		f.f1[2] * mul.y);
+    result.f2 = mat3(
+		f.f2[0] * mul.y,
+		f.f2[1] * mul.z,
+		f.f2[2] * mul.z);
+    result.f3 = mat3(
+		f.f3[0] * mul.z,
+		f.f3[1] * mul.z,
+		f.f3[2] * mul.z
+	);
+    return result;
+}
+
+vec3 sh_evaluate_convolved(sh3 f, vec3 kernel, vec3 direction) {
+	const vec3 k = sqrt(4.0 * pi / vec3(1.0, 3.0, 5.0));
+
+	vec3 mul = k * kernel;
+	mat3 coeff = sh_coeff_order_2(direction);
+
+	return coeff[0].x * f.f1[0] * mul.x
+	     + coeff[0].y * f.f1[1] * mul.y
+	     + coeff[0].z * f.f1[2] * mul.y
+	     + coeff[1].x * f.f2[0] * mul.y
+	     + coeff[1].y * f.f2[1] * mul.z
+	     + coeff[1].z * f.f2[2] * mul.z
+	     + coeff[2].x * f.f3[0] * mul.z
+	     + coeff[2].y * f.f3[1] * mul.z
+	     + coeff[2].z * f.f3[2] * mul.z;
+}
+
+// https://www.activision.com/cdn/research/Practical_Real_Time_Strategies_for_Accurate_Indirect_Occlusion_NEW%20VERSION_COLOR.pdf section 5
+vec3 sh_evaluate_irradiance(sh3 sh, vec3 bent_normal, float visibility) {
+	float aperture_angle_sin_sq = clamp01(visibility);
+	float aperture_angle_cos_sq = 1.0 - aperture_angle_sin_sq;
+
+	// Zonal harmonics expansion of visibility cone
+	vec3 kernel;
+	kernel.x = (sqrt(1.0 * pi) /  2.0) * aperture_angle_sin_sq;
+	kernel.y = (sqrt(3.0 * pi) /  3.0) * (1.0 - aperture_angle_cos_sq * sqrt(aperture_angle_cos_sq));
+	kernel.z = (sqrt(5.0 * pi) / 16.0) * aperture_angle_sin_sq * (2.0 + 6.0 * aperture_angle_cos_sq);
+
+	return sh_evaluate_convolved(sh, kernel, bent_normal);
+}
+
+#endif // INCLUDE_UTILITY_SPHERICAL_HARMONICS

--- a/shaders/program/d4a_generate_sky_sh.csh
+++ b/shaders/program/d4a_generate_sky_sh.csh
@@ -63,8 +63,11 @@ uniform float time_midnight;
 #include "/include/sky/projection.glsl"
 #include "/include/utility/random.glsl"
 #include "/include/utility/sampling.glsl"
-#include "/include/utility/spherical_harmonics.glsl"
-
+#ifdef MC_GL_RENDERER_INTEL
+	#include "/include/utility/spherical_harmonics_fallback.glsl"
+#else
+	#include "/include/utility/spherical_harmonics.glsl"
+#endif
 void main() {
 #ifndef SH_SKYLIGHT
     return;
@@ -80,14 +83,20 @@ void main() {
     vec3 direction = uniform_hemisphere_sample(vec3(0.0, 1.0, 0.0), r2(int(i)));
     vec3 radiance =
         texture(colortex4, project_sky(direction)).rgb * skylight_boost;
-    float[9] coeff = sh_coeff_order_2(direction);
+	#ifdef MC_GL_RENDERER_INTEL
+		mat3 coeff = sh_coeff_order_2(direction);
 
-    for (uint band = 0u; band < 9u; ++band) {
-        shared_memory[i][band] =
-            radiance * coeff[band] * (tau / float(sample_count));
-    }
+		for (uint band = 0u; band < 9u; ++band) {
+			shared_memory[i][band] = radiance * coeff[band / 3u][band % 3u] * (tau / float(sample_count));
+		}
+	#else
+		float[9] coeff = sh_coeff_order_2(direction);
 
-    barrier();
+		for (uint band = 0u; band < 9u; ++band) {
+			shared_memory[i][band] = radiance * coeff[band] * (tau / float(sample_count));
+		}
+	#endif
+	barrier();
 
 // Sum samples using parallel reduction
 
@@ -112,28 +121,37 @@ for (uint stride = sample_count / 2u; stride > 0u; stride /= 2u) {
     } \
     barrier();
 
-    PARALLEL_REDUCTION_ITER(128u)
-    PARALLEL_REDUCTION_ITER(64u)
-    PARALLEL_REDUCTION_ITER(32u)
-    PARALLEL_REDUCTION_ITER(16u)
-    PARALLEL_REDUCTION_ITER(8u)
-    PARALLEL_REDUCTION_ITER(4u)
-    PARALLEL_REDUCTION_ITER(2u)
-    PARALLEL_REDUCTION_ITER(1u)
+	PARALLEL_REDUCTION_ITER(128u)
+	PARALLEL_REDUCTION_ITER(64u)
+	PARALLEL_REDUCTION_ITER(32u)
+	PARALLEL_REDUCTION_ITER(16u)
+	PARALLEL_REDUCTION_ITER(8u)
+	PARALLEL_REDUCTION_ITER(4u)
+	PARALLEL_REDUCTION_ITER(2u)
+	PARALLEL_REDUCTION_ITER(1u)
 
-#undef PARALLEL_REDUCTION_ITER
+	#undef PARALLEL_REDUCTION_ITER
 
-    // Save SH coeff in colorimg4
+	// Save SH coeff in colorimg4
 
-    if (i == 0u) {
-        for (uint band = 0u; band < 9u; ++band) {
-            vec3 sh_coeff = shared_memory[0][band];
-            imageStore(colorimg4, ivec2(191, 2 + band), vec4(sh_coeff, 0.0));
-        }
+	if (i == 0u) {
+		for (uint band = 0u; band < 9u; ++band) {
+			vec3 sh_coeff = shared_memory[0][band];
+			imageStore(colorimg4, ivec2(191, 2 + band), vec4(sh_coeff, 0.0));
+		}
 
-        // Store irradiance facing up for forward lighting
-        vec3 irradiance_up =
-            sh_evaluate_irradiance(shared_memory[0], vec3(0.0, 1.0, 0.0), 1.0);
-        imageStore(colorimg4, ivec2(191, 2 + 9), vec4(irradiance_up, 0.0));
-    }
+		// Store irradiance facing up for forward lighting 
+		#ifdef MC_GL_RENDERER_INTEL
+			sh3 sh;
+			for (uint band = 0u; band < 3u; ++band) {
+				sh.f1[band] = shared_memory[0][band];
+				sh.f2[band] = shared_memory[0][band + 3u];
+				sh.f3[band] = shared_memory[0][band + 6u];
+			}
+			vec3 irradiance_up = sh_evaluate_irradiance(sh, vec3(0.0, 1.0, 0.0), 1.0);
+		#else
+			vec3 irradiance_up = sh_evaluate_irradiance(shared_memory[0], vec3(0.0, 1.0, 0.0), 1.0);
+		#endif
+		imageStore(colorimg4, ivec2(191, 2 + 9), vec4(irradiance_up, 0.0));
+	}
 }


### PR DESCRIPTION
This PR Fixed https://github.com/sixthsurge/photon/issues/384 by replacing every float[]/vec[] parameter/return vaue with vec4,mat3 and struct of mat3, because using them as parameter/return vaue may just crash the Intel GPU driver.


Tested on Iris Xe Graphics (i5-12500H intergrated).
SH Skylight ON:
<img width="1251" height="480" alt="2025-11-29_01 11 29" src="https://github.com/user-attachments/assets/8fe64071-6f9b-4484-b262-b26d0caa15cc" />
SH Skylight OFF:
<img width="1251" height="480" alt="2025-11-29_01 11 05" src="https://github.com/user-attachments/assets/d03baa8e-7b36-49b1-891a-9ea4db0443da" />

I'm not very familiar with GLSL and GPU Programming, so I don't know whether I should replace struct of mat3 with struct of vec3[], or whether struct of vec3[] would still crash the game.