### PR TITLE
Fixed SSRT banding on voxy LODs

### DIFF
--- a/shaders/include/lighting/shadows/ssrt.glsl
+++ b/shaders/include/lighting/shadows/ssrt.glsl
@@ -160,7 +160,7 @@ float get_screen_space_shadows(
             lod_depth_tex,
             lod_projection_matrix,
             lod_projection_matrix_inverse,
-            vec3(position_screen_xy, depth_lod),
+            vec3(position_screen_xy, depth),
             position_view,
             ray_dir,
             has_sss,


### PR DESCRIPTION
Idk why this works but it do
Based on https://github.com/sixthsurge/photon/issues/461