### PR TITLE
Better Vanilla Lightmap Contribution

### DIFF
--- a/shaders/include/lighting/lpv/blocklight.glsl
+++ b/shaders/include/lighting/lpv/blocklight.glsl
@@ -34,7 +34,9 @@ vec3 get_lpv_blocklight(vec3 scene_pos, vec3 normal, vec3 mc_blocklight, float a
 
 #ifdef COLORED_LIGHTS_VANILLA_LIGHTMAP_CONTRIBUTION
 		float vanilla_lightmap_contribution = exp2(-4.0 * dot(lpv_blocklight, luminance_weights_rec2020));
-		lpv_blocklight += mc_blocklight * vanilla_lightmap_contribution;
+		lpv_blocklight += 
+			mix(vec3(dot(mc_blocklight, luminance_weights_rec2020)), mc_blocklight, 0.5) * mc_blocklight * 0.5
+			* vanilla_lightmap_contribution;
 #endif
 
 		// Darkness effect


### PR DESCRIPTION
Changed vanilla lightmap contribution calculation to squared (close to natural behavior) instead of linear, with some desaturation to account for it. Reduces hard lightmap cuts and lighting issues in closed spaces with corners, as well as having better mixing with colored lights

Comparisons:
Old:
<img width="640" height="360" alt="2025-12-23_19 25 23" src="https://github.com/user-attachments/assets/15829836-383e-4a86-9b5a-8925488b8d67" />
New:
<img width="640" height="360" alt="2025-12-23_19 30 29" src="https://github.com/user-attachments/assets/1b10d3f9-9d02-4716-a3fe-ddbfc268cea7" />
Old:
<img width="640" height="360" alt="2025-12-23_19 35 27" src="https://github.com/user-attachments/assets/3952724d-6a8f-4d4a-a01a-1320776ff765" />
New:
<img width="640" height="360" alt="2025-12-23_19 35 52" src="https://github.com/user-attachments/assets/6888a6ff-5970-40a9-a018-09202e9443a8" />
