### PR TITLE
Fix Ambient Occlusion on Windows Intel

### DIFF
--- a/shaders/program/c17_copy_ao.fsh
+++ b/shaders/program/c17_copy_ao.fsh
@@ -1,0 +1,23 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+
+  program/program/c17_copy_ao.fsh:
+  manally copies colortex6 alt to main to fix ao on intel
+  
+--------------------------------------------------------------------------------
+*/
+
+#include "/include/global.glsl"
+
+layout(location = 0) out vec4 ao_history;
+
+/* RENDERTARGETS: 6 */
+
+uniform sampler2D colortex6;
+
+void main() {
+    ivec2 texel = ivec2(gl_FragCoord.xy);
+    ao_history = texelFetch(colortex6, texel, 0);
+}

--- a/shaders/program/c17_copy_ao.vsh
+++ b/shaders/program/c17_copy_ao.vsh
@@ -1,0 +1,16 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+
+  program/program/c17_copy_ao.vsh:
+  manally copies colortex6 alt to main to fix ao on intel
+
+--------------------------------------------------------------------------------
+*/
+
+#include "/include/global.glsl"
+
+void main() {
+  gl_Position = vec4(gl_Vertex.xy * 2.0 - 1.0, 0.0, 1.0);
+}

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -167,6 +167,11 @@ program.world0/composite12.enabled = BLOOM
 program.world0/composite13.enabled = BLOOM
 program.world0/composite15.enabled = MOTION_BLUR
 program.world0/composite16.enabled = FXAA
+#ifdef MC_GL_RENDERER_INTEL
+	program.world0/composite17.enabled = true
+#else
+	program.world0/composite17.enabled = false
+#endif
 program.world0/setup.enabled       = COLORED_LIGHTS
 program.world0/shadowcomp.enabled  = COLORED_LIGHTS
 program.world0/deferred4_a.enabled = SH_SKYLIGHT
@@ -187,6 +192,11 @@ program.world-1/composite12.enabled = BLOOM
 program.world-1/composite13.enabled = BLOOM
 program.world-1/composite15.enabled = MOTION_BLUR
 program.world-1/composite16.enabled = FXAA
+#ifdef MC_GL_RENDERER_INTEL
+	program.world-1/composite17.enabled = true
+#else
+	program.world-1/composite17.enabled = false
+#endif
 program.world-1/prepare.enabled      = false
 program.world-1/setup.enabled       = COLORED_LIGHTS
 program.world-1/shadowcomp.enabled  = COLORED_LIGHTS
@@ -207,6 +217,11 @@ program.world1/composite12.enabled = BLOOM
 program.world1/composite13.enabled = BLOOM
 program.world1/composite15.enabled = MOTION_BLUR
 program.world1/composite16.enabled = FXAA
+#ifdef MC_GL_RENDERER_INTEL
+	program.world1/composite17.enabled = true
+#else
+	program.world1/composite17.enabled = false
+#endif
 program.world1/prepare.enabled     = false
 program.world1/setup.enabled       = COLORED_LIGHTS
 program.world1/shadowcomp.enabled  = COLORED_LIGHTS

--- a/shaders/world-1/composite17.fsh
+++ b/shaders/world-1/composite17.fsh
@@ -1,0 +1,4 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define fsh
+#include "/program/c17_copy_ao.fsh"

--- a/shaders/world-1/composite17.vsh
+++ b/shaders/world-1/composite17.vsh
@@ -1,0 +1,4 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define vsh
+#include "/program/c17_copy_ao.vsh"

--- a/shaders/world0/composite17.fsh
+++ b/shaders/world0/composite17.fsh
@@ -1,0 +1,4 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define fsh
+#include "/program/c17_copy_ao.fsh"

--- a/shaders/world0/composite17.vsh
+++ b/shaders/world0/composite17.vsh
@@ -1,0 +1,4 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define vsh
+#include "/program/c17_copy_ao.vsh"

--- a/shaders/world1/composite17.fsh
+++ b/shaders/world1/composite17.fsh
@@ -1,0 +1,4 @@
+#version 400 compatibility
+#define WORLD_END
+#define fsh
+#include "/program/c17_copy_ao.fsh"

--- a/shaders/world1/composite17.vsh
+++ b/shaders/world1/composite17.vsh
@@ -1,0 +1,4 @@
+#version 400 compatibility
+#define WORLD_END
+#define vsh
+#include "/program/c17_copy_ao.vsh"


### PR DESCRIPTION
Again there's a fix for Windows Intel, and finally Photon will run perfectly on this platform.

The bug is specificially because Windows Intel don't correctly handle the additional copy after `final` that moves the `colortex6` `alt` to `main`, so we have to manually do it in an additional composite pass.
see https://discord.com/channels/1007736612488220724/1431965328644243616/1458997418506063903 for more details.

It seems that this pass doesn't cause noticeable performance loss, and I made this pass automatically turn off itself on non `MC_GL_RENDERER_INTEL` (roughly, Intel official driver on Windows) platform.

Comparison with white world on, other settings default:
- Before the fix:
   <img width="1280" height="720" alt="2026-01-12_12 14 34" src="https://github.com/user-attachments/assets/7bd50bd8-cef1-41c1-8698-dfbc1e8352dc" />

- After the fix:
   <img width="1280" height="720" alt="2026-01-12_12 14 55" src="https://github.com/user-attachments/assets/91e37e86-0018-4169-aa2d-363c5b7cefef" />

- What it should have been, taken on Mesa Intel:
   <img width="1280" height="720" alt="2026-01-12_12 19 45" src="https://github.com/user-attachments/assets/23756aac-0eaa-4a87-9024-f7dfd7f0305c" />
