### PR TITLE
Add height offset check in POM self shadow

### DIFF
--- a/shaders/include/surface/parallax.glsl
+++ b/shaders/include/surface/parallax.glsl
@@ -80,9 +80,12 @@ bool get_parallax_shadow(
 
     pos.xy += ray_step.xy * dither;
 
+    float max_height = get_depth_value(pos.xy, uv_gradient);
     for (int i = 0; i < POM_SHADOW_SAMPLES; ++i) {
         pos += ray_step;
-        if (get_depth_value(pos.xy, uv_gradient) < pos.z) {
+        float offset_height = get_depth_value(pos.xy, uv_gradient);
+        float diff = pos.z - offset_height;
+        if (diff > 0.0 && max_height - offset_height > eps) {
             return true;
         }
     }


### PR DESCRIPTION
Removes the flickering by casting shadows from only the top surface of POM layers
<img width="1440" height="720" alt="image" src="https://github.com/user-attachments/assets/5f2c3051-6040-4a32-b4df-c64e4f51dba0" />
