### PR TITLE
Fix: use `abs() < eps` instead of `!= 0.0`

### DIFF
--- a/shaders/program/d4_deferred_shading.fsh
+++ b/shaders/program/d4_deferred_shading.fsh
@@ -397,7 +397,7 @@ void main() {
 		vec4 ambient_upscaled;
 		float weight_sum = w00 + w10 + w01 + w11;
 
-		if (weight_sum != 0.0) {
+		if (abs(weight_sum) <= eps) {
 			ambient_upscaled 
 				= ambient_00 * w00 
 				+ ambient_10 * w10 


### PR DESCRIPTION
 `!= 0.0` will leak some very small floating point values into wrong codepath, and would make ao values contain inf and nan, causing black blocks flashing on some drivers