### PR TITLE
Adding Glowing Ore's

### DIFF
--- a/shaders/block.properties
+++ b/shaders/block.properties
@@ -317,6 +317,40 @@ block.10079 = light_gray_stained_glass light_gray_stained_glass_pane
 # Transparent
 block.10080 = snow redstone_wire string tripwire glass glass_pane chain minecraft:tall_seagrass cave_vines_plant:berries=false cave_vines:berries=false sea_pickle:waterlogged=false rail lever grindstone bell daylight_sensor powered_rail:powered=false repeater:powered=false comparator:powered=false stone_button polished_blackstone_button stone_pressure_plate polished_blackstone_pressure_plate nether_brick_fence cobblestone_wall mossy_cobblestone_wall stone_brick_wall mossy_stone_brick_wall granite_wall diorite_wall andesite_wall cobbled_deepslate_wall polished_deepslate_wall deepslate_brick_wall deepslate_tile_wall brick_wall mud_brick_wall sandstone_wall red_sandstone_wall prismarine_wall nether_brick_wall red_nether_brick_wall blackstone_wall polished_blackstone_wall polished_blackstone_brick_wall end_stone_brick_wall pointed_dripstone:thickness=tip pointed_dripstone:thickness=frustum big_dripleaf_stem big_dripleaf activator_rail:powered=false potted_cherry_sapling potted_dandelion potted_poppy potted_blue_orchid potted_allium potted_azure_bluet potted_red_tulip potted_orange_tulip potted_white_tulip potted_pink_tulip potted_oxeye_daisy potted_cornflower potted_lily_of_the_valley potted_wither_rose potted_oak_sapling potted_spruce_sapling potted_birch_sapling potted_jungle_sapling potted_acacia_sapling potted_dark_oak_sapling potted_red_mushroom potted_brown_mushroom potted_fern potted_dead_bush potted_cactus potted_bamboo potted_azalea_bush potted_flowering_azalea_bush potted_warped_roots potted_mangrove_propagule flower_pot bamboo_sapling detector_rail:powered=false white_carpet orange_carpet magenta_carpet light_blue_carpet yellow_carpet lime_carpet pink_carpet gray_carpet light_gray_carpet cyan_carpet purple_carpet blue_carpet brown_carpet green_carpet red_carpet black_carpet moss_carpet pointed_dripstone:thickness=tip_merge white_bed orange_bed magenta_bed light_blue_bed yellow_bed lime_bed pink_bed gray_bed light_gray_bed cyan_bed purple_bed blue_bed brown_bed green_bed red_bed black_bed stonecutter dried_ghast
 
+# --------------------------------------
+#   10081-10081 - Glowing Ores - @lechixy
+# --------------------------------------
+
+# Weak diamond light
+block.10081 = diamond_ore deepslate_diamond_ore
+
+# Weak emerald light
+block.10082 = emerald_ore deepslate_emerald_ore
+
+# Weak coal light
+block.10083 = coal_ore deepslate_coal_ore
+
+# Weak redstone light
+block.10084 = redstone_ore deepslate_redstone_ore
+
+# Weak lapis lazuli light
+block.10085 = lapis_ore deepslate_lapis_ore
+
+# Weak quartz light
+block.10086 = nether_quartz_ore
+
+# Medium netherite light
+block.10087 = ancient_debris
+
+# Weak golden light
+block.10088 = gold_ore deepslate_gold_ore nether_gold_ore
+
+# Weak copper light
+block.10089 = copper_ore deepslate_copper_ore
+
+# Weak iron light
+block.10090 = iron_ore deepslate_iron_ore
+
 #-------------------------------------------------------------------------------
 # 1.12 block mapping
 #-------------------------------------------------------------------------------

--- a/shaders/include/lighting/lpv/floodfill.glsl
+++ b/shaders/include/lighting/lpv/floodfill.glsl
@@ -3,12 +3,44 @@
 
 #include "voxelization.glsl"
 
-bool is_emitter(uint block_id) { return 32u <= block_id && block_id < 64u; }
+bool is_emitter(uint block_id) {
+	return (32u <= block_id && block_id < 64u) || (80u < block_id && block_id < 96u);
+}
 
-bool is_translucent(uint block_id) { return 64u <= block_id && block_id < 80u; }
+bool is_translucent(uint block_id) {
+	return 64u <= block_id && block_id < 80u;
+}
 
 vec3 get_emitted_light(uint block_id) {
     if (is_emitter(block_id)) {
+
+	// If this light is glowing ores (81–96) - @lechixy
+	if (block_id >= 81u) {
+		int idx = int(block_id - 81u);
+		const vec3[16] new_colors = vec3[16](
+			vec3(0.60, 0.90, 1.00) * 1.00, // Weak diamond light
+			vec3(0.00, 1.00, 0.40) * 1.00, // Weak emerald light
+			vec3(0.10, 0.10, 0.12) * 1.00, // Weak coal light
+			vec3(1.00, 0.10, 0.10) * 1.00, // Weak redstone light
+			vec3(0.15, 0.30, 1.00) * 1.00, // Weak lapis lazuli light
+			vec3(1.00, 0.85, 0.90) * 1.00, // Weak quartz light
+			vec3(0.40, 0.20, 0.15) * 6.00, // Medium netherite light
+			vec3(1.00, 0.85, 0.25) * 1.00, // Weak golden light
+			vec3(0.95, 0.60, 0.20) * 1.00, // Weak copper light
+			vec3(0.90, 0.75, 0.55) * 1.00, // Weak iron light
+				
+			// This colors are empty
+			vec3(1.00, 0.10, 0.10), // bright red
+			vec3(0.20, 1.00, 0.80), // turquoise
+			vec3(0.50, 0.40, 1.00), // lavender
+			vec3(1.00, 0.70, 0.10), // orange
+			vec3(0.70, 1.00, 0.70), // pastel green
+			vec3(0.40, 0.40, 0.40)  // dim gray
+		);
+			
+		return new_colors[idx % 16];
+	}
+
         return texelFetch(light_data_sampler, ivec2(int(block_id) - 32, 0), 0)
             .rgb;
     } else {

--- a/shaders/include/surface/material.glsl
+++ b/shaders/include/surface/material.glsl
@@ -811,6 +811,12 @@ Material material_from(
                 }
             }
         }
+    // If this materials are glowing ores - @lechixy
+    } else if((material_mask > 80u) && (material_mask < 91u)) {
+	#ifdef HARDCODED_EMISSION
+	// Weak white light
+	material.emission = 0.2 * albedo_sqrt * (0.1 + 0.9 * pow4(hsl.z));
+	#endif
     }
 
     if (64u <= material_mask && material_mask < 80u) {


### PR DESCRIPTION
I think the missing feature of photon is not having native support to glowing ore's. If you ask me why don't you use a resource pack: shader light based glowing ore makes shader and game complete, resource packs looks awful with photon's aesthetics.

TODO
- Adding option to enable/disable Glowing Ore in the shader settings menu
- Refactoring floodfill.glsl because i didn't add colors to texel_fetch(light_data_sampler)

- Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ab27de2a-0b27-46c3-b398-b9d29a400981" />

- After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/78f1bae1-2372-4300-907b-d4d83c3b856d" />