### PR TITLE
fix: prevent hand ghosting and flickering against clouds

### DIFF
--- a/shaders/program/d2_clouds_upscaling.fsh
+++ b/shaders/program/d2_clouds_upscaling.fsh
@@ -257,7 +257,7 @@ void main() {
     if (depth != 1.0) {
         float view_distance_squared =
             length_squared(screen_to_view_space(vec3(uv, depth), true));
-        if (view_distance_squared < sqr(closest_distance) && !is_hand) {
+        if (view_distance_squared < sqr(closest_distance) || is_hand) {
             clouds_history = current;
             clouds_data.x = 1e6; // apparent distance
             clouds_data.y = 0.0; // pixel age


### PR DESCRIPTION
| Before | After |
| :---: | :---: |
| <img width="640" height="342" alt="2026-02-27_23 52 29" src="https://github.com/user-attachments/assets/058639e9-c928-40c8-a7ab-b6c5c247f3b7" /> | <img width="640" height="342" alt="2026-02-27_23 54 15" src="https://github.com/user-attachments/assets/50c5e6e4-113c-4cc8-b243-140be431284a" /> |

Issue: Severe ghosting and flickering on the player's hand/held items when viewed against clouds.

Fix: In d2_clouds_upscaling.fsh, changed the early exit condition from && !is_hand to || is_hand.
This allows the hand pixels to properly early exit instead of being forced into the cloud temporal reprojection/upscaling logic