### PR TITLE
fix: prevent motionblur overblurring terrain behind transparent blocks

### DIFF
--- a/shaders/program/c16_motion_blur.fsh
+++ b/shaders/program/c16_motion_blur.fsh
@@ -23,7 +23,7 @@ in vec2 uv;
 
 uniform sampler2D colortex0; // Scene color
 
-uniform sampler2D depthtex0;
+uniform sampler2D depthtex1;
 
 uniform mat4 gbufferModelView;
 uniform mat4 gbufferModelViewInverse;
@@ -53,7 +53,7 @@ void main() {
     ivec2 texel = ivec2(gl_FragCoord.xy);
     ivec2 view_texel = ivec2(gl_FragCoord.xy * taau_render_scale);
 
-    float depth = texelFetch(depthtex0, view_texel, 0).x;
+    float depth = texelFetch(depthtex1, view_texel, 0).x;
 
     if (depth < hand_depth) {
         scene_color = texelFetch(colortex0, texel, 0).rgb;
@@ -74,7 +74,7 @@ void main() {
         ivec2 view_tap = ivec2(pos * view_res * taau_render_scale);
 
         vec3 color = texelFetch(colortex0, tap, 0).rgb;
-        float depth = texelFetch(depthtex0, view_tap, 0).x;
+        float depth = texelFetch(depthtex1, view_tap, 0).x;
         float weight = (clamp01(pos) == pos && depth > hand_depth) ? 1.0 : 0.0;
 
         color_sum += color * weight;


### PR DESCRIPTION
uses depthtex1 for depth instead of depthtex0

walking in the image
Before:
<img width="2560" height="1600" alt="before" src="https://github.com/user-attachments/assets/9e55cd37-46d6-4dd6-af93-4218312dcff5" />
After:
<img width="2560" height="1600" alt="after" src="https://github.com/user-attachments/assets/2331cc0f-a8a9-45de-bcf0-7106f2bcbeda" />
