### PR TITLE
fix breaking overlay before mc26.1

### DIFF
--- a/shaders/program/d4_deferred_shading.fsh
+++ b/shaders/program/d4_deferred_shading.fsh
@@ -13,7 +13,7 @@
 
 layout(location = 0) out vec3 fragment_color;
 
-#ifdef USE_SEPARATE_ENTITY_DRAWS
+#if MC_VERSION > 12111
 /* RENDERTARGETS: 0 */
 #else
 layout(location = 1) out vec4 colortex3_clear;
@@ -58,7 +58,7 @@ uniform sampler2D colortex11; // clouds history
 uniform sampler2D colortex12; // clouds data
 uniform sampler2D colortex14; // ambient lighting history data
 
-#ifndef USE_SEPARATE_ENTITY_DRAWS
+#if !(MC_VERSION > 12111)
 uniform sampler2D colortex3; // OF damage overlay, armor glint
 #endif
 
@@ -190,7 +190,7 @@ const bool colortex11MipmapEnabled = true;
 #endif
 
 void main() {
-#if !defined USE_SEPARATE_ENTITY_DRAWS
+#if !(MC_VERSION > 12111)
     colortex3_clear = vec4(0.0);
 #endif
 
@@ -203,7 +203,7 @@ void main() {
 #if defined NORMAL_MAPPING || defined SPECULAR_MAPPING
     vec4 gbuffer_data_1 = texelFetch(colortex2, texel, 0);
 #endif
-#if !defined USE_SEPARATE_ENTITY_DRAWS
+#if !(MC_VERSION > 12111)
     vec4 overlays = texelFetch(colortex3, texel, 0);
 #endif
 
@@ -346,7 +346,7 @@ void main() {
         vec3 flat_normal = decode_unit_vector(data[2]);
         vec2 light_levels = data[3];
 
-#if !defined USE_SEPARATE_ENTITY_DRAWS
+#if !(MC_VERSION > 12111)
         uint overlay_id = uint(255.0 * overlays.a);
         albedo = overlay_id == 0u ? albedo + overlays.rgb
                                   : albedo; // enchantment glint

--- a/shaders/program/gbuffers_damagedblock.fsh
+++ b/shaders/program/gbuffers_damagedblock.fsh
@@ -13,7 +13,7 @@
 
 layout(location = 0) out vec4 damage_overlay;
 
-#ifdef USE_SEPARATE_ENTITY_DRAWS
+#if MC_VERSION > 12111
 /* RENDERTARGETS: 0 */
 #else
 /* RENDERTARGETS: 3 */
@@ -47,7 +47,7 @@ void main() {
         discard;
     }
 
-#ifdef USE_SEPARATE_ENTITY_DRAWS
+#if MC_VERSION > 12111
     damage_overlay.rgb =
         0.5 * srgb_eotf_inv(2.0 * damage_overlay.rgb) * rec709_to_rec2020;
     damage_overlay.a = 1.0;

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -325,6 +325,9 @@ blend.shadow                         = off
 blend.gbuffers_armor_glint.colortex13 = ONE ONE ZERO ONE
 #else
 blend.gbuffers_armor_glint            = off
+#endif
+
+#if !(MC_VERSION > 12111)
 blend.gbuffers_damagedblock           = off
 #endif
 


### PR DESCRIPTION
in minecraft 26.1, damagedblock is after deferred. it is necessary to handle the breaking overlay in the composite pass.