### PR TITLE
Misc and water fixes

### DIFF
--- a/shaders/include/lighting/specular_lighting.glsl
+++ b/shaders/include/lighting/specular_lighting.glsl
@@ -186,7 +186,7 @@ vec3 sample_ggx_vndf(vec3 viewer_dir, vec2 alpha, vec2 hash) {
 
 vec3 get_sky_reflection(vec3 ray_dir, float skylight, vec3 hit_pos) {
 #if defined WORLD_OVERWORLD
-    bool hit_sky = clamp01(hit_pos.xy) == hit_pos.xy && hit_pos.z >= 1.0;
+    bool hit_sky = false; //clamp01(hit_pos.xy) == hit_pos.xy && hit_pos.z >= 1.0;
     float skylight_falloff =
         hit_sky ? 1.0 : pow12(linear_step(0.0, 0.75, skylight));
     return bicubic_filter(colortex4, project_sky(ray_dir)).rgb *

--- a/shaders/program/gbuffers_all_solid.fsh
+++ b/shaders/program/gbuffers_all_solid.fsh
@@ -86,6 +86,8 @@ uniform vec2 taa_offset;
 
 uniform vec3 light_dir;
 
+uniform float alphaTestRef;
+
 #if defined PROGRAM_GBUFFERS_ENTITIES
 uniform int entityId;
 uniform vec4 entityColor;
@@ -294,12 +296,12 @@ void main() {
     if (material_mask == MATERIAL_LIGHTNING_BOLT) {
         base_color = vec4(1.0);
     }
-    if (base_color.a < 0.1 && material_mask != MATERIAL_BOAT) {
+    if (base_color.a < alphaTestRef && material_mask != MATERIAL_BOAT) {
         discard;
         return;
     } // Save transparent quad in boats, which masks out water
 #elif !defined PROGRAM_GBUFFERS_TERRAIN_SOLID
-    if (base_color.a < 0.1) {
+    if (base_color.a < alphaTestRef) {
         discard;
         return;
     }

--- a/shaders/program/gbuffers_all_solid.vsh
+++ b/shaders/program/gbuffers_all_solid.vsh
@@ -93,7 +93,7 @@ uniform int currentRenderedItemId;
 #include "/include/vertex/utility.glsl"
 
 void main() {
-    uv = gl_MultiTexCoord0.xy;
+    uv = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
     light_levels = clamp01(gl_MultiTexCoord1.xy * rcp(240.0));
     tint = gl_Color;
     material_mask = get_material_mask();

--- a/shaders/program/gbuffers_all_translucent.fsh
+++ b/shaders/program/gbuffers_all_translucent.fsh
@@ -278,8 +278,7 @@ vec4 water_absorption_approx(
     );
 
     float brightness_control = 1.0 - exp(-0.33 * layer_dist);
-    brightness_control =
-        (1.0 - light_levels.y) + brightness_control * light_levels.y;
+    brightness_control *= max(light_levels.x, light_levels.y);
 
     return vec4(
         color.rgb +

--- a/shaders/program/gbuffers_basic.fsh
+++ b/shaders/program/gbuffers_basic.fsh
@@ -82,7 +82,6 @@ void main() {
     }
 #endif
 
-#if defined IS_IRIS && defined USE_SEPARATE_ENTITY_DRAWS
     scene_color.rgb = srgb_eotf_inv(base_color.rgb) * rec709_to_working_color;
     // see note in function
     scene_color.a = fixup_translucent(tint.a);
@@ -90,7 +89,6 @@ void main() {
     if (renderStage == MC_RENDER_STAGE_OUTLINE) {
         scene_color.rgb *= 1.0 + BOX_EMISSION;
     }
-#endif
 
     vec2 encoded_normal = encode_unit_vector(normal);
 

--- a/shaders/program/shadow.fsh
+++ b/shaders/program/shadow.fsh
@@ -123,7 +123,7 @@ float get_water_caustics() {
             tbn[2],
             coord,
             flow_dir,
-            1.0,
+            1.0 - rainStrength,
             flowing_water
         );
 

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -280,26 +280,26 @@ size.buffer.colortex10 = 0.25 0.25
 #   Blending
 # ------------
 
-alphaTest.dh_water                       = off
-alphaTest.gbuffers_armor_glint           = off
-alphaTest.gbuffers_basic                 = off
-alphaTest.gbuffers_block                 = off
-alphaTest.gbuffers_damagedblock          = off
-alphaTest.gbuffers_entities              = off
-alphaTest.gbuffers_hand                  = off
-alphaTest.gbuffers_hand_water            = off
-alphaTest.gbuffers_line                  = off
-alphaTest.gbuffers_particles             = off
-alphaTest.gbuffers_spidereyes            = off
-alphaTest.gbuffers_skytextured           = off
-alphaTest.gbuffers_terrain               = off
-alphaTest.gbuffers_textured              = off
-alphaTest.gbuffers_block_translucent     = off
-alphaTest.gbuffers_entities_translucent  = off
-alphaTest.gbuffers_particles_translucent = off
-alphaTest.gbuffers_water                 = off
-alphaTest.gbuffers_weather               = off
-alphaTest.shadow                         = off
+# alphaTest.dh_water                       = off
+# alphaTest.gbuffers_armor_glint           = off
+# alphaTest.gbuffers_basic                 = off
+# alphaTest.gbuffers_block                 = off
+# alphaTest.gbuffers_damagedblock          = off
+# alphaTest.gbuffers_entities              = off
+# alphaTest.gbuffers_hand                  = off
+# alphaTest.gbuffers_hand_water            = off
+# alphaTest.gbuffers_line                  = off
+# alphaTest.gbuffers_particles             = off
+# alphaTest.gbuffers_spidereyes            = off
+# alphaTest.gbuffers_skytextured           = off
+# alphaTest.gbuffers_terrain               = off
+# alphaTest.gbuffers_textured              = off
+# alphaTest.gbuffers_block_translucent     = off
+# alphaTest.gbuffers_entities_translucent  = off
+# alphaTest.gbuffers_particles_translucent = off
+# alphaTest.gbuffers_water                 = off
+# alphaTest.gbuffers_weather               = off
+# alphaTest.shadow                         = off
 
 blend.dh_water                       = off
 blend.gbuffers_armor_glint           = off


### PR DESCRIPTION
These fixes are especially needed for users playing with CAVE_LIGHTING_I=0.00
Before:
<img width="2560" height="1440" alt="Screenshot From 2026-04-12 15-05-19" src="https://github.com/user-attachments/assets/53bfa6f8-3287-4596-8859-d49182b3f354" />
After:
<img width="2560" height="1440" alt="Screenshot From 2026-04-12 15-05-35" src="https://github.com/user-attachments/assets/f1957f8b-32b4-4924-933f-9908cab78aa7" />
Notice bright geometry on the screenshot before - it's a bug with SSR, attempting to reflect sky and the workaround is in 949384ec97897028b44ad22b6418d35a504fed3e
Water was also lit without any light due to odd brightness_control calculation in `water_absorption_approx` - fixed in 789c4932dedbf7dc7905d9d1eda0f9af8460a9eb

Fixed mipmaps in c9f9ee4e5a96003c2270167bd626b83c1c066558:
<img width="976" height="850" alt="image" src="https://github.com/user-attachments/assets/6d0d59f4-96bc-4ab5-ae5e-d67b374dbd33" />
<img width="976" height="850" alt="image" src="https://github.com/user-attachments/assets/81da8cad-97b4-4880-a0df-00ddec90b3f1" />

Water caustics look really bright during rain, so a change in 9de6a3673eba92c796d75c42e9bf437cf82895ae is neccessary:

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/7cea2da7-9525-4a9e-a0c5-171761438a2a" />

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8496bcea-6ded-4e94-864f-1466f142db77" />
