### PR TITLE
Add basic Colorwheel Support

### DIFF
--- a/shaders/program/gbuffers_all_solid.fsh
+++ b/shaders/program/gbuffers_all_solid.fsh
@@ -29,7 +29,6 @@ layout(
 #endif
 
 in vec2 uv;
-in vec2 light_levels;
 in vec3 scene_pos;
 in vec4 tint;
 
@@ -43,8 +42,14 @@ flat in vec2 atlas_tile_offset;
 flat in vec2 atlas_tile_scale;
 #endif
 
+#ifdef COLORWHEEL
+vec2 light_levels;
+float vanilla_ao;
+#else
+in vec2 light_levels;
 #if defined PROGRAM_GBUFFERS_TERRAIN
 in float vanilla_ao;
+#endif
 #endif
 
 #if defined PROGRAM_GBUFFERS_ENTITIES || defined PROGRAM_GBUFFERS_HAND
@@ -284,7 +289,23 @@ void main() {
 
     //--//
 
-    vec4 base_color = read_tex(gtexture) * tint;
+    vec4 base_color;
+#if defined COLORWHEEL
+    base_color = read_tex(gtexture);
+    vec4 overlayColor;
+
+    clrwl_computeFragment(
+        base_color,
+        base_color,
+        light_levels,
+        vanilla_ao,
+        overlayColor
+    );
+    light_levels = clamp((light_levels - 1.0 / 32.0) * 32.0 / 30.0, 0.0, 1.0);
+#else
+    base_color = read_tex(gtexture) * tint;
+#endif
+
 #ifdef NORMAL_MAPPING
     vec3 normal_map = read_tex(normals).xyz;
 #endif
@@ -343,6 +364,10 @@ void main() {
 
 #if defined PROGRAM_GBUFFERS_ENTITIES
     base_color.rgb = mix(base_color.rgb, entityColor.rgb, entityColor.a);
+#endif
+
+#if defined COLORWHEEL
+    base_color.rgb = mix(base_color.rgb, overlayColor.rgb, overlayColor.a);
 #endif
 
 #if defined PROGRAM_GBUFFERS_BLOCK

--- a/shaders/program/gbuffers_all_solid.vsh
+++ b/shaders/program/gbuffers_all_solid.vsh
@@ -12,12 +12,17 @@
 #include "/include/global.glsl"
 
 out vec2 uv;
-out vec2 light_levels;
 out vec3 scene_pos;
 out vec4 tint;
 
 flat out uint material_mask;
 flat out mat3 tbn;
+
+#if defined COLORWHEEL
+vec2 light_levels;
+#else
+out vec2 light_levels;
+#endif
 
 #if defined POM
 out vec2 atlas_tile_coord;
@@ -28,6 +33,8 @@ flat out vec2 atlas_tile_scale;
 
 #if defined PROGRAM_GBUFFERS_TERRAIN
 out float vanilla_ao;
+#elif defined COLORWHEEL
+float vanilla_ao;
 #endif
 
 #if defined PROGRAM_GBUFFERS_ENTITIES || defined PROGRAM_GBUFFERS_HAND
@@ -116,7 +123,7 @@ void main() {
 #endif
 #endif
 
-#if defined PROGRAM_GBUFFERS_ENTITIES
+#if defined PROGRAM_GBUFFERS_ENTITIES && !defined COLORWHEEL
     // Fix fire entity not glowing with Colored Lights
     if (light_levels.x > 0.99) {
         material_mask = 40;

--- a/shaders/program/shadow.fsh
+++ b/shaders/program/shadow.fsh
@@ -11,7 +11,11 @@
 
 #include "/include/global.glsl"
 
+#if defined COLORWHEEL
+layout(location = 0) out vec4 shadowcolor0_out;
+#else
 layout(location = 0) out vec3 shadowcolor0_out;
+#endif
 
 /* RENDERTARGETS: 0 */
 
@@ -146,6 +150,7 @@ float get_water_caustics() {
 }
 
 void main() {
+#ifndef COLORWHEEL
     if (material_mask == 1) { // Water
 #if defined PROGRAM_SHADOW_WATER || defined PROGRAM_SHADOW_FALLBACK
         vec3 biome_water_color = srgb_eotf_inv(tint) * rec709_to_working_color;
@@ -169,4 +174,23 @@ void main() {
             = 0.25 * srgb_eotf_inv(shadowcolor0_out) * rec709_to_rec2020;
         shadowcolor0_out *= step(base_color.a, 1.0 - rcp(255.0));
     }
+#else
+    vec4 base_color = textureLod(tex, uv, 0);
+    vec2 lmcoord;
+    float ao;
+    vec4 overlayColor;
+
+    clrwl_computeFragment(base_color, base_color, lmcoord, ao, overlayColor);
+    base_color.rgb = mix(base_color.rgb, overlayColor.rgb, overlayColor.a);
+
+    if (base_color.a < 0.1) {
+        discard;
+    }
+
+    vec3 outColor = mix(vec3(1.0), base_color.rgb, base_color.a);
+    outColor = 0.25 * srgb_eotf_inv(outColor) * rec709_to_rec2020;
+    outColor *= step(base_color.a, 1.0 - rcp(255.0));
+
+    shadowcolor0_out = vec4(outColor, 1.0);
+#endif
 }

--- a/shaders/world-1/clrwl_gbuffers.fsh
+++ b/shaders/world-1/clrwl_gbuffers.fsh
@@ -1,0 +1,8 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_TERRAIN
+#define PROGRAM_GBUFFERS_BLOCK
+#define PROGRAM_GBUFFERS_ENTITIES
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_all_solid.fsh"

--- a/shaders/world-1/clrwl_gbuffers.vsh
+++ b/shaders/world-1/clrwl_gbuffers.vsh
@@ -1,0 +1,8 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_TERRAIN
+#define PROGRAM_GBUFFERS_BLOCK
+#define PROGRAM_GBUFFERS_ENTITIES
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_all_solid.vsh"

--- a/shaders/world-1/clrwl_shadow.fsh
+++ b/shaders/world-1/clrwl_shadow.fsh
@@ -1,0 +1,9 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_SOLID
+#define PROGRAM_SHADOW_BLOCK
+#define PROGRAM_SHADOW_ENTITIES
+#define COLORWHEEL
+#define fsh
+#include "/program/shadow.fsh"

--- a/shaders/world-1/clrwl_shadow.vsh
+++ b/shaders/world-1/clrwl_shadow.vsh
@@ -1,0 +1,9 @@
+#version 400 compatibility
+#extension GL_ARB_shader_image_load_store : enable
+#define WORLD_NETHER
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_SOLID
+#define PROGRAM_SHADOW_BLOCK
+#define PROGRAM_SHADOW_ENTITIES
+#define vsh
+#include "/program/shadow.vsh"

--- a/shaders/world0/clrwl_gbuffers.fsh
+++ b/shaders/world0/clrwl_gbuffers.fsh
@@ -1,0 +1,8 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_TERRAIN
+#define PROGRAM_GBUFFERS_BLOCK
+#define PROGRAM_GBUFFERS_ENTITIES
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_all_solid.fsh"

--- a/shaders/world0/clrwl_gbuffers.vsh
+++ b/shaders/world0/clrwl_gbuffers.vsh
@@ -1,0 +1,8 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_TERRAIN
+#define PROGRAM_GBUFFERS_BLOCK
+#define PROGRAM_GBUFFERS_ENTITIES
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_all_solid.vsh"

--- a/shaders/world0/clrwl_shadow.fsh
+++ b/shaders/world0/clrwl_shadow.fsh
@@ -1,0 +1,9 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_SOLID
+#define PROGRAM_SHADOW_BLOCK
+#define PROGRAM_SHADOW_ENTITIES
+#define COLORWHEEL
+#define fsh
+#include "/program/shadow.fsh"

--- a/shaders/world0/clrwl_shadow.vsh
+++ b/shaders/world0/clrwl_shadow.vsh
@@ -1,0 +1,9 @@
+#version 400 compatibility
+#extension GL_ARB_shader_image_load_store : enable
+#define WORLD_OVERWORLD
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_SOLID
+#define PROGRAM_SHADOW_BLOCK
+#define PROGRAM_SHADOW_ENTITIES
+#define vsh
+#include "/program/shadow.vsh"

--- a/shaders/world1/clrwl_gbuffers.fsh
+++ b/shaders/world1/clrwl_gbuffers.fsh
@@ -1,0 +1,8 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_TERRAIN
+#define PROGRAM_GBUFFERS_BLOCK
+#define PROGRAM_GBUFFERS_ENTITIES
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_all_solid.fsh"

--- a/shaders/world1/clrwl_gbuffers.vsh
+++ b/shaders/world1/clrwl_gbuffers.vsh
@@ -1,0 +1,8 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_TERRAIN
+#define PROGRAM_GBUFFERS_BLOCK
+#define PROGRAM_GBUFFERS_ENTITIES
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_all_solid.vsh"

--- a/shaders/world1/clrwl_shadow.fsh
+++ b/shaders/world1/clrwl_shadow.fsh
@@ -1,0 +1,9 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_SOLID
+#define PROGRAM_SHADOW_BLOCK
+#define PROGRAM_SHADOW_ENTITIES
+#define COLORWHEEL
+#define fsh
+#include "/program/shadow.fsh"

--- a/shaders/world1/clrwl_shadow.vsh
+++ b/shaders/world1/clrwl_shadow.vsh
@@ -1,0 +1,9 @@
+#version 400 compatibility
+#extension GL_ARB_shader_image_load_store : enable
+#define WORLD_END
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_SOLID
+#define PROGRAM_SHADOW_BLOCK
+#define PROGRAM_SHADOW_ENTITIES
+#define vsh
+#include "/program/shadow.vsh"


### PR DESCRIPTION
Add a define named `COLORWHEEL` like this:
```glsl
#ifdef COLORWHEEL
vec2 light_levels;
float vanilla_ao;
#else
in vec2 light_levels;
#if defined PROGRAM_GBUFFERS_TERRAIN
in float vanilla_ao;
#endif
#endif
```
I'm not sure if there is a better way to implement this, this is my first time using GLSL.
Now, the block and shadow of that should be rendered correctly.

<img width="1920" height="1080" alt="2026-04-16_13 13 46" src="https://github.com/user-attachments/assets/cef26807-9bf0-462b-bbb0-28b8eef1c1a7" />
