### PR TITLE
Add Physics Mod ocean support and Colorwheel (Flywheel) integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Photon Shaders - Clean PR.zip

--- a/shaders/colorwheel.properties
+++ b/shaders/colorwheel.properties
@@ -1,0 +1,27 @@
+# colorwheel.properties
+# Colorwheel (Flywheel 1.0) integration config for Photon
+#
+# OIT (Order-Independent Transparency) — required for Create mod translucent
+# parts (e.g. glass, fluid tanks) to composite correctly with Photon's
+# deferred layers.
+#
+# colortex0 is used as the OIT accumulation buffer.
+# colortex1 (frontmost) is Photon's gbuffer_data_0 — we keep it as frontmost
+# so only the closest Colorwheel fragment ends up in the gbuffer, which is
+# how Photon expects its gbuffer to work (one fragment per pixel, resolved
+# in the deferred pass via colortex13 for translucency).
+
+oit = true
+
+oit.gbuffers.coefficientRanks = 3
+
+# colortex0: OIT accumulation (standard)
+oit.gbuffers.colortex0 = 0
+
+# colortex1: Photon gbuffer_data_0 — frontmost fragment only
+oit.gbuffers.colortex1 = frontmost
+oit.gbuffers.colortex1.format = RGBA32F
+
+# shadowcolor0: frontmost shadow fragment for shadow map correctness
+oit.shadow.shadowcolor0 = frontmost
+oit.shadow.shadowcolor0.format = RGB16F

--- a/shaders/program/clrwl_gbuffers.fsh
+++ b/shaders/program/clrwl_gbuffers.fsh
@@ -1,0 +1,97 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+
+  program/clrwl_gbuffers:
+  Colorwheel (Flywheel 1.0) instanced geometry - fragment stage
+
+  Colorwheel injects clrwl_computeFragment() at runtime. Its signature is:
+    void clrwl_computeFragment(
+        inout vec4 fragColor,   // base color in, modified in-place
+        in    vec4 baseColor,   // original base color (same as above on entry)
+        out   vec2 lmcoord,     // lightmap coords [0,1] returned by Colorwheel
+        out   float ao,         // ambient occlusion [0,1] returned by Colorwheel
+        out   vec4 overlayColor // tint overlay to mix on top (pre-multiplied alpha)
+    );
+
+  We write into Photon's colortex1 (gbuffer_data_0) so the deferred pipeline
+  shades Colorwheel geometry identically to normal terrain/entities.
+
+  gbuffer_data_0 layout (must match gbuffers_all_solid.fsh exactly):
+    .x = pack_unorm_2x8(albedo.rg)
+    .y = pack_unorm_2x8(albedo.b, material_mask / 255.0)
+    .z = pack_unorm_2x8(encode_unit_vector(flat_normal))
+    .w = pack_unorm_2x8(light_levels)
+
+--------------------------------------------------------------------------------
+*/
+
+#include "/include/global.glsl"
+
+// Write into Photon's gbuffer channel — same rendertarget as gbuffers_all_solid.
+layout(location = 0) out vec4 gbuffer_data_0;
+
+/* RENDERTARGETS: 1 */
+
+in vec2 texcoord;
+in vec2 lmcoord;
+in vec4 glcolor;
+in vec3 world_normal;
+
+// ------------
+//   Uniforms
+// ------------
+
+uniform sampler2D gtexture;
+uniform int frameCounter;
+
+#include "/include/utility/encoding.glsl"
+#include "/include/utility/dithering.glsl"
+
+void main() {
+    // ----- Base color -----
+    vec4 base_color = texture(gtexture, texcoord) * glcolor;
+
+    // Discard fully transparent fragments (alpha cut-out)
+    if (base_color.a < 0.1) { discard; return; }
+
+    // ----- Colorwheel overlay -----
+    // clrwl_computeFragment is injected by Colorwheel at compile-time.
+    // lmcoord_out and ao_out are written by Colorwheel; they encode the
+    // per-instance lighting / AO baked by Flywheel.
+    vec2  lmcoord_out;
+    float ao_out;
+    vec4  overlay_color;
+
+    clrwl_computeFragment(base_color, base_color, lmcoord_out, ao_out, overlay_color);
+
+    // Mix Colorwheel overlay on top of the base color
+    base_color.rgb = mix(base_color.rgb, overlay_color.rgb, overlay_color.a);
+
+    // Apply ambient occlusion from Colorwheel
+    base_color.rgb *= ao_out;
+
+    // ----- Light levels -----
+    // Colorwheel returns lmcoord_out in raw lightmap space [0, 240].
+    // Normalize to [0, 1] to match what Photon stores in the gbuffer.
+    vec2 light_levels = clamp01(lmcoord_out * rcp(240.0));
+
+    // ----- Normal -----
+    // Normalize the interpolated world-space normal.
+    vec3 flat_normal = normalize(world_normal);
+
+    // ----- Material mask -----
+    // Flywheel instances have no Photon material mask — use 0 (generic solid).
+    // Hardcoded emission is not applied; Create machinery should not glow.
+    const float material_mask_f = 0.0;
+
+    // ----- Dither -----
+    float dither = interleaved_gradient_noise(gl_FragCoord.xy, frameCounter);
+
+    // ----- Pack into gbuffer_data_0 (same layout as gbuffers_all_solid.fsh) -----
+    gbuffer_data_0.x = pack_unorm_2x8(base_color.rg);
+    gbuffer_data_0.y = pack_unorm_2x8(base_color.b, material_mask_f);
+    gbuffer_data_0.z = pack_unorm_2x8(encode_unit_vector(flat_normal));
+    gbuffer_data_0.w = pack_unorm_2x8(dither_8bit(light_levels, dither));
+}

--- a/shaders/program/clrwl_gbuffers.vsh
+++ b/shaders/program/clrwl_gbuffers.vsh
@@ -1,0 +1,43 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+
+  program/clrwl_gbuffers:
+  Colorwheel (Flywheel 1.0) instanced geometry - vertex stage
+
+  Colorwheel injects clrwl_computeFragment() at runtime.
+  This program must NOT use Photon's existing gbuffers varyings;
+  it is a standalone program called only by Colorwheel.
+
+--------------------------------------------------------------------------------
+*/
+
+#include "/include/global.glsl"
+
+// Colorwheel-injected instance data comes in through standard gl_* attributes.
+// We output the minimal set of varyings needed for the fragment stage.
+
+out vec2 texcoord;
+out vec2 lmcoord;
+out vec4 glcolor;
+out vec3 world_normal;
+
+// ------------
+//   Uniforms
+// ------------
+
+uniform mat4 gbufferModelViewInverse;
+
+void main() {
+    gl_Position = ftransform();
+
+    texcoord    = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
+    lmcoord     = (gl_TextureMatrix[1] * gl_MultiTexCoord1).xy;
+    glcolor     = gl_Color;
+
+    // Transform normal: model-view space → world/player space
+    // This matches how gbuffers_all_solid.vsh builds the TBN matrix.
+    vec3 view_normal = gl_NormalMatrix * gl_Normal;
+    world_normal     = mat3(gbufferModelViewInverse) * view_normal;
+}

--- a/shaders/program/clrwl_shadow.fsh
+++ b/shaders/program/clrwl_shadow.fsh
@@ -1,0 +1,59 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+
+  program/clrwl_shadow:
+  Colorwheel (Flywheel 1.0) instanced geometry - shadow fragment stage
+
+  Outputs to shadowcolor0 in Photon's shadow color format:
+    0.25 * srgb_eotf_inv(color) * rec709_to_rec2020
+
+  This matches the output of shadow.fsh for normal geometry so that
+  Photon's shadow sampling code treats both identically.
+
+  clrwl_computeFragment is called here so Colorwheel can read back shadow
+  visibility per-instance if it needs it. The overlay is applied before
+  writing so translucent overlays affect shadow tinting correctly.
+
+--------------------------------------------------------------------------------
+*/
+
+#include "/include/global.glsl"
+
+layout(location = 0) out vec3 shadowcolor0_out;
+
+/* RENDERTARGETS: 0 */
+
+in vec2 texcoord;
+in vec4 glcolor;
+
+// ------------
+//   Uniforms
+// ------------
+
+uniform sampler2D gtexture;
+
+#include "/include/utility/color.glsl"
+
+void main() {
+    vec4 base_color = textureLod(gtexture, texcoord, 0) * glcolor;
+
+    // Alpha cut-out — discard fully transparent shadow casters
+    if (base_color.a < 0.1) { discard; return; }
+
+    // ----- Colorwheel overlay -----
+    vec2  lmcoord_out;
+    float ao_out;
+    vec4  overlay_color;
+
+    clrwl_computeFragment(base_color, base_color, lmcoord_out, ao_out, overlay_color);
+    base_color.rgb = mix(base_color.rgb, overlay_color.rgb, overlay_color.a);
+
+    // ----- Shadow color output -----
+    // Matches shadow.fsh: multiply/darken fully opaque surfaces, skip for
+    // translucent ones (step() zeroes the output when alpha < 1 - 1/255).
+    shadowcolor0_out  = mix(vec3(1.0), base_color.rgb, base_color.a);
+    shadowcolor0_out  = 0.25 * srgb_eotf_inv(shadowcolor0_out) * rec709_to_rec2020;
+    shadowcolor0_out *= step(base_color.a, 1.0 - rcp(255.0));
+}

--- a/shaders/program/clrwl_shadow.vsh
+++ b/shaders/program/clrwl_shadow.vsh
@@ -1,0 +1,41 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+
+  program/clrwl_shadow:
+  Colorwheel (Flywheel 1.0) instanced geometry - shadow vertex stage
+
+  Applies Photon's shadow projection and distortion, matching shadow.vsh.
+  No vertex animations — Flywheel instances are static within a frame.
+
+--------------------------------------------------------------------------------
+*/
+
+#include "/include/global.glsl"
+
+out vec2 texcoord;
+out vec4 glcolor;
+
+// ------------
+//   Uniforms
+// ------------
+
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+
+// Photon's shadow distortion — must match what shadow.vsh uses so that
+// clrwl_shadow samples overlap correctly with the main shadow map.
+#include "/include/lighting/shadows/distortion.glsl"
+
+void main() {
+    texcoord = (gl_TextureMatrix[0] * gl_MultiTexCoord0).xy;
+    glcolor  = gl_Color;
+
+    // Transform to shadow clip space and apply Photon's distortion.
+    vec3 pos            = transform(gl_ModelViewMatrix, gl_Vertex.xyz);
+    vec3 shadow_clip    = project_ortho(gl_ProjectionMatrix, pos);
+         shadow_clip    = distort_shadow_space(shadow_clip);
+
+    gl_Position = vec4(shadow_clip, 1.0);
+}

--- a/shaders/program/gbuffers_all_solid.fsh
+++ b/shaders/program/gbuffers_all_solid.fsh
@@ -33,7 +33,7 @@ in vec3 scene_pos;
 in vec4 tint;
 
 flat in uint material_mask;
-flat in mat3 tbn;
+in mat3 tbn;
 
 #if defined POM
 in vec2 atlas_tile_coord;

--- a/shaders/program/gbuffers_all_solid.vsh
+++ b/shaders/program/gbuffers_all_solid.vsh
@@ -16,7 +16,7 @@ out vec3 scene_pos;
 out vec4 tint;
 
 flat out uint material_mask;
-flat out mat3 tbn;
+out mat3 tbn;
 
 #if defined COLORWHEEL
 vec2 light_levels;

--- a/shaders/program/gbuffers_all_translucent.fsh
+++ b/shaders/program/gbuffers_all_translucent.fsh
@@ -30,7 +30,7 @@ in vec3 position_scene;
 in vec4 tint;
 
 flat in uint material_mask;
-flat in mat3 tbn;
+in mat3 tbn;
 
 #if defined PROGRAM_GBUFFERS_WATER
 in vec2 atlas_tile_coord;

--- a/shaders/program/gbuffers_all_translucent.vsh
+++ b/shaders/program/gbuffers_all_translucent.vsh
@@ -19,7 +19,7 @@ out vec3 position_scene;
 out vec4 tint;
 
 flat out uint material_mask;
-flat out mat3 tbn;
+out mat3 tbn;
 
 #if defined PROGRAM_GBUFFERS_WATER
 out vec2 atlas_tile_coord;

--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -628,3 +628,7 @@ uniform.vec4.combined_projection_matrix_inverse_1 = vec4(0.0, gbufferProjectionI
 uniform.vec4.combined_projection_matrix_inverse_2 = vec4(0.0, 0.0, 0.0, -(combined_far - combined_near) / (2.0 * combined_far * combined_near))
 uniform.vec4.combined_projection_matrix_inverse_3 = vec4(gbufferProjectionInverse.3.0, gbufferProjectionInverse.3.1, -1.0, (combined_far + combined_near) / (2.0 * combined_far * combined_near))
 #endif
+
+# Physics Mod Ocean Support
+customTextures = physics_waviness physics_ripples physics_foam physics_lightmap
+customUniforms = physics_iterationsNormal physics_waveOffset physics_textureOffset physics_gameTime physics_oceanHeight physics_oceanWaveHorizontalScale physics_modelOffset physics_rippleRange physics_foamAmount physics_foamOpacity physics_globalTime

--- a/shaders/world-1/clrwl_gbuffers.fsh
+++ b/shaders/world-1/clrwl_gbuffers.fsh
@@ -1,8 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (Nether gbuffers)
+ */
+
 #define WORLD_NETHER
-#define PROGRAM_GBUFFERS_TERRAIN
-#define PROGRAM_GBUFFERS_BLOCK
-#define PROGRAM_GBUFFERS_ENTITIES
-#define COLORWHEEL
 #define fsh
-#include "/program/gbuffers_all_solid.fsh"
+#include "/program/clrwl_gbuffers.fsh"

--- a/shaders/world-1/clrwl_gbuffers.vsh
+++ b/shaders/world-1/clrwl_gbuffers.vsh
@@ -1,8 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (Nether gbuffers)
+ */
+
 #define WORLD_NETHER
-#define PROGRAM_GBUFFERS_TERRAIN
-#define PROGRAM_GBUFFERS_BLOCK
-#define PROGRAM_GBUFFERS_ENTITIES
-#define COLORWHEEL
 #define vsh
-#include "/program/gbuffers_all_solid.vsh"
+#include "/program/clrwl_gbuffers.vsh"

--- a/shaders/world-1/clrwl_shadow.fsh
+++ b/shaders/world-1/clrwl_shadow.fsh
@@ -1,9 +1,9 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (Nether shadow)
+ * Nether has no sun shadows in Photon (shadow.vsh discards),
+ * but Colorwheel still needs this program to exist so it doesn't fall back.
+ */
+
 #define WORLD_NETHER
-#define PROGRAM_SHADOW
-#define PROGRAM_SHADOW_SOLID
-#define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
-#define COLORWHEEL
 #define fsh
-#include "/program/shadow.fsh"
+#include "/program/clrwl_shadow.fsh"

--- a/shaders/world-1/clrwl_shadow.vsh
+++ b/shaders/world-1/clrwl_shadow.vsh
@@ -1,9 +1,7 @@
-#version 400 compatibility
-#extension GL_ARB_shader_image_load_store : enable
+/*
+ * Photon - Colorwheel support (Nether shadow)
+ */
+
 #define WORLD_NETHER
-#define PROGRAM_SHADOW
-#define PROGRAM_SHADOW_SOLID
-#define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
 #define vsh
-#include "/program/shadow.vsh"
+#include "/program/clrwl_shadow.vsh"

--- a/shaders/world-1/physics_ocean.fsh
+++ b/shaders/world-1/physics_ocean.fsh
@@ -1,0 +1,423 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean.fsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define fsh
+
+#include "/include/global.glsl"
+
+layout (location = 0) out vec4 refraction_data;
+layout (location = 1) out vec4 fragment_color;
+
+/* RENDERTARGETS: 3,13 */
+
+in vec2 uv;
+in vec2 light_levels;
+in vec3 position_view;
+in vec3 position_scene;
+in vec4 tint;
+
+flat in vec3 light_color;
+flat in vec3 ambient_color;
+flat in uint material_mask;
+in mat3 tbn;
+
+in vec2 atlas_tile_coord;
+in vec3 position_tangent;
+flat in vec2 atlas_tile_offset;
+flat in vec2 atlas_tile_scale;
+
+in vec3 physics_localPosition;
+in float physics_localWaviness;
+
+#if defined WORLD_NETHER
+#include "/include/fog/overworld/parameters.glsl"
+flat in OverworldFogParameters fog_params;
+#endif
+
+uniform sampler2D noisetex;
+uniform sampler2D gtexture;
+uniform sampler2D normals;
+uniform sampler2D specular;
+uniform sampler2D colortex4;
+uniform sampler2D colortex5;
+uniform sampler2D colortex7;
+
+#ifdef CLOUD_SHADOWS
+uniform sampler2D colortex8;
+#endif
+
+uniform sampler2D depthtex1;
+
+#ifdef COLORED_LIGHTS
+uniform sampler3D light_sampler_a;
+uniform sampler3D light_sampler_b;
+#endif
+
+#ifdef SHADOW
+uniform sampler2D shadowtex0;
+uniform sampler2DShadow shadowtex1;
+#endif
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferPreviousModelView;
+uniform mat4 gbufferPreviousProjection;
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+uniform mat4 shadowProjection;
+uniform mat4 shadowProjectionInverse;
+
+uniform vec3 cameraPosition;
+uniform vec3 previousCameraPosition;
+
+uniform float near;
+uniform float far;
+uniform float frameTimeCounter;
+uniform float sunAngle;
+uniform float rainStrength;
+uniform float wetness;
+
+uniform int worldTime;
+uniform int moonPhase;
+uniform int frameCounter;
+uniform int isEyeInWater;
+
+uniform float blindness;
+uniform float nightVision;
+uniform float darknessFactor;
+uniform float eyeAltitude;
+
+uniform vec3 light_dir;
+uniform vec3 sun_dir;
+uniform vec3 moon_dir;
+
+uniform vec2 view_res;
+uniform vec2 view_pixel_size;
+uniform vec2 taa_offset;
+
+uniform float eye_skylight;
+uniform float biome_cave;
+uniform float biome_may_rain;
+uniform float biome_may_snow;
+
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_globalTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform vec3 physics_modelOffset;
+uniform float physics_rippleRange;
+uniform float physics_foamAmount;
+uniform float physics_foamOpacity;
+uniform sampler2D physics_waviness;
+uniform sampler2D physics_ripples;
+uniform sampler3D physics_foam;
+
+// Physics Mod constants
+const float PHYSICS_NORMAL_STRENGTH = 1.4;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_W_DETAIL = 0.75;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+const float PHYSICS_DRAG_MULT = 0.048;
+
+vec3 physics_waveNormal(const in vec2 position, const in vec2 direction, const in float factor, const in float time) {
+    float oceanHeightFactor = physics_oceanHeight / 13.0;
+    float totalFactor = oceanHeightFactor * factor;
+    vec3 waveNormal = normalize(vec3(direction.x * totalFactor, PHYSICS_NORMAL_STRENGTH, direction.y * totalFactor));
+    
+    vec2 eyePosition = position + physics_modelOffset.xz;
+    vec2 rippleFetch = (eyePosition + vec2(physics_rippleRange)) / (physics_rippleRange * 2.0);
+    vec2 rippleTexelSize = vec2(2.0 / textureSize(physics_ripples, 0).x, 0.0);
+    float left = texture(physics_ripples, rippleFetch - rippleTexelSize.xy).r;
+    float right = texture(physics_ripples, rippleFetch + rippleTexelSize.xy).r;
+    float top = texture(physics_ripples, rippleFetch - rippleTexelSize.yx).r;
+    float bottom = texture(physics_ripples, rippleFetch + rippleTexelSize.yx).r;
+    float totalEffect = left + right + top + bottom;
+    
+    float normalx = left - right;
+    float normalz = top - bottom;
+    vec3 rippleNormal = normalize(vec3(normalx, 1.0, normalz));
+    return normalize(mix(waveNormal, rippleNormal, pow(totalEffect, 0.5)));
+}
+
+struct WavePixelData {
+    vec2 direction;
+    vec2 worldPos;
+    vec3 normal;
+    float foam;
+    float height;
+};
+
+WavePixelData physics_wavePixel(const in vec2 position, const in float factor, const in float iterations, const in float time) {
+    vec2 wavePos = (position.xy - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    vec2 dx = vec2(0.0);
+    
+    for (int i = 0; i < int(iterations); i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, wavePos) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        dx += force / pow(weight, PHYSICS_W_DETAIL);
+        wavePos -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    WavePixelData data;
+    data.direction = -vec2(dx / pow(waveSum, 1.0 - PHYSICS_W_DETAIL));
+    data.worldPos = wavePos / physics_oceanWaveHorizontalScale / PHYSICS_XZ_SCALE;
+    data.height = height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+    
+    data.normal = physics_waveNormal(position, data.direction, factor, time);
+
+    float waveAmplitude = data.height * pow(max(data.normal.y, 0.0), 4.0);
+    vec2 waterUV = mix(position - physics_waveOffset, data.worldPos, clamp(factor * 2.0, 0.2, 1.0));
+    
+    vec2 s1 = textureLod(physics_foam, vec3(waterUV * 0.26, physics_globalTime / 360.0), 0).rg;
+    vec2 s2 = textureLod(physics_foam, vec3(waterUV * 0.02, physics_globalTime / 360.0 + 0.5), 0).rg;
+    vec2 s3 = textureLod(physics_foam, vec3(waterUV * 0.1, physics_globalTime / 360.0 + 1.0), 0).rg;
+    
+    float waterSurfaceNoise = s1.r * s2.r * s3.r * 2.8 * physics_foamAmount;
+    waveAmplitude = clamp(waveAmplitude * 1.2, 0.0, 1.0);
+    waterSurfaceNoise = (1.0 - waveAmplitude) * waterSurfaceNoise + waveAmplitude * physics_foamAmount;
+    
+    float worleyNoise = 0.2 + 0.8 * s1.g * (1.0 - s2.g);
+    float waterFoamMinSmooth = 0.45;
+    float waterFoamMaxSmooth = 2.0;
+    waterSurfaceNoise = smoothstep(waterFoamMinSmooth, 1.0, waterSurfaceNoise) * worleyNoise;
+    
+    data.foam = clamp(waterFoamMaxSmooth * waterSurfaceNoise * physics_foamOpacity, 0.0, 1.0);
+    
+    return data;
+}
+
+#define TEMPORAL_REPROJECTION
+
+#ifdef SHADOW_COLOR
+    #undef SHADOW_COLOR
+#endif
+
+#ifdef DIRECTIONAL_LIGHTMAPS
+#include "/include/lighting/directional_lightmaps.glsl"
+#endif
+
+#include "/include/fog/simple_fog.glsl"
+#include "/include/lighting/diffuse_lighting.glsl"
+
+#include "/include/lighting/shadows/pcss.glsl"
+#include "/include/lighting/specular_lighting.glsl"
+#include "/include/misc/lod_mod_support.glsl"
+#include "/include/surface/material.glsl"
+#include "/include/misc/material_masks.glsl"
+#include "/include/misc/purkinje_shift.glsl"
+#include "/include/surface/water_normal.glsl"
+#include "/include/utility/color.glsl"
+#include "/include/utility/encoding.glsl"
+#include "/include/utility/fast_math.glsl"
+#include "/include/utility/space_conversion.glsl"
+
+#ifdef CLOUD_SHADOWS
+#include "/include/lighting/cloud_shadows.glsl"
+#endif
+
+const float lod_bias = log2(taau_render_scale);
+
+Material get_water_material_physics(vec3 direction_world, vec3 normal, float layer_dist, float foam, out float alpha) {
+    Material material = water_material;
+    alpha = 0.01;
+
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT || WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    vec4 base_color = texture(gtexture, uv, lod_bias);
+    float texture_highlight = dampen(0.5 * sqr(linear_step(0.63, 1.0, base_color.r)) + 0.03 * base_color.r);
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    texture_highlight *= 1.0 - cube(linear_step(0.0, 0.5, light_levels.y));
+#endif
+    material.albedo = clamp01(0.5 * exp(-2.0 * water_absorption_coeff) * texture_highlight);
+    material.roughness += 0.3 * texture_highlight;
+    alpha += texture_highlight;
+#elif WATER_TEXTURE == WATER_TEXTURE_VANILLA
+    vec4 base_color = texture(gtexture, uv, lod_bias) * tint;
+    material.albedo = srgb_eotf_inv(base_color.rgb * base_color.a) * rec709_to_working_color;
+    alpha = base_color.a;
+#endif
+
+    // Physics Mod foam
+    material.albedo = mix(material.albedo, vec3(1.0), foam * 0.8);
+    alpha = max(alpha, foam);
+
+#ifdef WATER_EDGE_HIGHLIGHT
+    float dist = layer_dist * max(abs(direction_world.y), eps);
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT || WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    float edge_highlight = cube(max0(1.0 - 2.0 * dist)) * (1.0 + 8.0 * texture_highlight);
+#else
+    float edge_highlight = cube(max0(1.0 - 2.0 * dist));
+#endif
+    edge_highlight *= WATER_EDGE_HIGHLIGHT_INTENSITY * max0(normal.y) * (1.0 - 0.5 * sqr(light_levels.y));
+    material.albedo += 0.1 * edge_highlight / mix(1.0, max(dot(ambient_color, luminance_weights_rec2020), 0.5), light_levels.y);
+    material.albedo = clamp01(material.albedo);
+    alpha += edge_highlight;
+#endif
+
+    return material;
+}
+
+vec4 water_absorption_approx_physics(vec4 color, float sss_depth, float layer_dist, float LoV, float NoV, float cloud_shadows) {
+    vec3 biome_water_color = srgb_eotf_inv(tint.rgb) * rec709_to_working_color;
+    vec3 absorption_coeff = biome_water_coeff(biome_water_color);
+    float dist = layer_dist * float(isEyeInWater != 1 || NoV >= 0.0);
+
+    mat2x3 water_fog = water_fog_simple(light_color * cloud_shadows, ambient_color, absorption_coeff, light_levels, dist, -LoV, sss_depth);
+
+    float brightness_control = 1.0 - exp(-0.33 * layer_dist);
+    brightness_control = (1.0 - light_levels.y) + brightness_control * light_levels.y;
+
+    return vec4(color.rgb + water_fog[0] * (1.0 + 6.0 * sqr(water_fog[1])) * brightness_control, 1.0 - water_fog[1].x);
+}
+
+void main() {
+    vec2 coord = gl_FragCoord.xy * view_pixel_size * rcp(taau_render_scale);
+
+#if defined TAA && defined TAAU
+    if (clamp01(coord) != coord) discard;
+#endif
+
+    // Physics Mod wave calculation
+    WavePixelData wave = physics_wavePixel(physics_localPosition.xz, physics_localWaviness, float(physics_iterationsNormal), physics_gameTime);
+    
+    vec3 physics_normal = wave.normal;
+    if (!gl_FrontFacing) physics_normal = -physics_normal;
+
+    float depth0 = gl_FragCoord.z;
+    float depth1 = texelFetch(depthtex1, ivec2(gl_FragCoord.xy), 0).x;
+
+    vec3 world_pos = position_scene + cameraPosition;
+    vec3 direction_world = normalize(position_scene - gbufferModelViewInverse[3].xyz);
+
+    vec3 view_back_pos = screen_to_view_space(vec3(coord, depth1), true);
+
+#ifdef DISTANT_HORIZONS
+    float depth1_dh = texelFetch(dhDepthTex1, ivec2(gl_FragCoord.xy), 0).x;
+    if (is_lod_terrain(depth1, depth1_dh)) {
+        view_back_pos = screen_to_view_space(vec3(coord, depth1_dh), true, true);
+    }
+#endif
+
+    vec3 scene_back_pos = view_to_scene_space(view_back_pos);
+    float layer_dist = distance(position_scene, scene_back_pos);
+
+    Material material;
+    vec3 normal = physics_normal;
+    vec3 normal_tangent = vec3(physics_normal.x, physics_normal.z, physics_normal.y);
+
+    bool is_water = material_mask == MATERIAL_WATER;
+    vec2 adjusted_light_levels = light_levels;
+
+    if (is_water) {
+        material = get_water_material_physics(direction_world, normal, layer_dist, wave.foam, fragment_color.a);
+    } else {
+        fragment_color = texture(gtexture, uv, lod_bias) * tint;
+        if (fragment_color.a < 0.1) { discard; return; }
+        material = material_from(fragment_color.rgb, material_mask, world_pos, tbn[2], adjusted_light_levels);
+    }
+
+    float NoL = dot(normal, light_dir);
+    float NoV = clamp01(dot(normal, -direction_world));
+    float LoV = dot(light_dir, -direction_world);
+    float halfway_norm = inversesqrt(2.0 * LoV + 2.0);
+    float NoH = (NoL + NoV) * halfway_norm;
+    float LoH = LoV * halfway_norm + halfway_norm;
+
+#if defined WORLD_NETHER && defined CLOUD_SHADOWS
+    float cloud_shadows = get_cloud_shadows(colortex8, position_scene);
+#else
+    #define cloud_shadows 1.0
+#endif
+
+#if defined SHADOW && defined WORLD_NETHER
+    float sss_depth;
+    float shadow_distance_fade;
+    vec3 shadows = get_filtered_shadows(position_scene, tbn[2], adjusted_light_levels.y, cloud_shadows, material.sss_amount, shadow_distance_fade, sss_depth);
+#else
+    #define sss_depth 0.0
+    #define shadow_distance_fade 0.0
+    vec3 shadows = vec3(pow8(adjusted_light_levels.y));
+#endif
+
+    fragment_color.rgb = get_diffuse_lighting(
+        material, position_scene, normal, tbn[2], tbn[2], shadows, adjusted_light_levels, 1.0, 0.0, sss_depth,
+#ifdef CLOUD_SHADOWS
+        cloud_shadows,
+#endif
+        shadow_distance_fade, NoL, NoV, NoH, LoV
+    ) * fragment_color.a;
+
+#if defined WORLD_NETHER
+    fragment_color.rgb += get_specular_highlight(material, NoL, NoV, NoH, LoV, LoH) * light_color * shadows * cloud_shadows;
+#endif
+
+#if defined ENVIRONMENT_REFLECTIONS || defined SKY_REFLECTIONS
+    if (material.ssr_multiplier > eps) {
+        vec3 position_screen = vec3(gl_FragCoord.xy * rcp(taau_render_scale) * view_pixel_size, gl_FragCoord.z);
+        mat3 new_tbn = get_tbn_matrix(normal);
+        fragment_color.rgb += get_specular_reflections(material, new_tbn, position_screen, position_view, world_pos, normal, tbn[2], direction_world, direction_world * new_tbn, light_levels.y, is_water);
+    }
+#endif
+
+    if (is_water) {
+        fragment_color = water_absorption_approx_physics(fragment_color, sss_depth, layer_dist, LoV, dot(tbn[2], direction_world), cloud_shadows);
+
+#ifdef SNELLS_WINDOW
+        if (isEyeInWater == 1) {
+            fragment_color.a = mix(fragment_color.a, 1.0, fresnel_dielectric_n(NoV, air_n / water_n).x);
+        }
+#endif
+    }
+
+    vec4 fog = common_fog(length(position_scene), false);
+    fragment_color.rgb = fragment_color.rgb * fog.a + fog.rgb;
+    fragment_color.rgb = purkinje_shift(fragment_color.rgb, adjusted_light_levels);
+
+    refraction_data.xy = split_2x8(normal_tangent.x * 0.5 + 0.5);
+    refraction_data.zw = split_2x8(normal_tangent.y * 0.5 + 0.5);
+}

--- a/shaders/world-1/physics_ocean.vsh
+++ b/shaders/world-1/physics_ocean.vsh
@@ -1,0 +1,223 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean.vsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define vsh
+
+#include "/include/global.glsl"
+
+out vec2 uv;
+out vec2 light_levels;
+out vec3 position_view;
+out vec3 position_scene;
+out vec4 tint;
+
+flat out vec3 light_color;
+flat out vec3 ambient_color;
+flat out uint material_mask;
+out mat3 tbn;
+
+out vec2 atlas_tile_coord;
+out vec3 position_tangent;
+flat out vec2 atlas_tile_offset;
+flat out vec2 atlas_tile_scale;
+
+out vec3 physics_localPosition;
+out float physics_localWaviness;
+
+#if defined WORLD_NETHER
+#include "/include/fog/overworld/parameters.glsl"
+flat out OverworldFogParameters fog_params;
+#endif
+
+attribute vec4 at_tangent;
+attribute vec3 mc_Entity;
+attribute vec2 mc_midTexCoord;
+
+uniform sampler2D noisetex;
+uniform sampler2D colortex4;
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+
+uniform vec3 cameraPosition;
+uniform float near;
+uniform float far;
+uniform ivec2 atlasSize;
+uniform int renderStage;
+uniform int worldTime;
+uniform int worldDay;
+uniform int frameCounter;
+uniform float frameTimeCounter;
+uniform float sunAngle;
+uniform float rainStrength;
+uniform float wetness;
+uniform vec2 view_res;
+uniform vec2 view_pixel_size;
+uniform vec2 taa_offset;
+uniform vec3 light_dir;
+uniform vec3 sun_dir;
+uniform float eye_skylight;
+
+uniform float biome_temperate;
+uniform float biome_arid;
+uniform float biome_snowy;
+uniform float biome_taiga;
+uniform float biome_jungle;
+uniform float biome_swamp;
+uniform float biome_may_rain;
+uniform float biome_may_snow;
+uniform float biome_temperature;
+uniform float biome_humidity;
+uniform float world_age;
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+uniform float desert_sandstorm;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform vec3 physics_modelOffset;
+uniform sampler2D physics_waviness;
+
+// Physics Mod constants
+const int PHYSICS_ITERATIONS_OFFSET = 13;
+const float PHYSICS_DRAG_MULT = 0.048;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+
+float physics_waveHeight(vec2 position, int iterations, float factor, float time) {
+    position = (position - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    
+    for (int i = 0; i < iterations; i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, position) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        position -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    return height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+}
+
+#include "/include/misc/material_masks.glsl"
+#include "/include/utility/space_conversion.glsl"
+#include "/include/vertex/displacement.glsl"
+
+#if defined WORLD_NETHER
+#include "/include/weather/fog.glsl"
+#endif
+
+uint get_material_mask_physics() {
+    return uint(max(0.0, mc_Entity.x - 10000.0));
+}
+
+mat3 get_tbn_matrix_physics() {
+    mat3 tbn_matrix;
+    tbn_matrix[0] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * at_tangent.xyz);
+    tbn_matrix[2] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * gl_Normal);
+    tbn_matrix[1] = cross(tbn_matrix[0], tbn_matrix[2]) * sign(at_tangent.w);
+    return tbn_matrix;
+}
+
+void main() {
+    uv            = mat2(gl_TextureMatrix[0]) * gl_MultiTexCoord0.xy + gl_TextureMatrix[0][3].xy;
+    light_levels  = clamp01(gl_MultiTexCoord1.xy * rcp(240.0));
+    tint          = gl_Color;
+    material_mask = get_material_mask_physics();
+    tbn           = get_tbn_matrix_physics();
+
+    light_color   = texelFetch(colortex4, ivec2(191, 0), 0).rgb;
+#if defined WORLD_NETHER && defined SH_SKYLIGHT
+    ambient_color = texelFetch(colortex4, ivec2(191, 11), 0).rgb;
+#else
+    ambient_color = texelFetch(colortex4, ivec2(191, 1), 0).rgb;
+#endif
+
+    // Physics Mod wave calculation
+    physics_localWaviness = texelFetch(physics_waviness, ivec2(gl_Vertex.xz) - physics_textureOffset, 0).r;
+    
+    vec4 physics_vertex = vec4(
+        gl_Vertex.x,
+        gl_Vertex.y + physics_waveHeight(gl_Vertex.xz, PHYSICS_ITERATIONS_OFFSET, physics_localWaviness, physics_gameTime),
+        gl_Vertex.z,
+        gl_Vertex.w
+    );
+    
+    physics_localPosition = physics_vertex.xyz;
+
+    bool is_top_vertex = uv.y < mc_midTexCoord.y;
+
+    position_scene = transform(gl_ModelViewMatrix, physics_vertex.xyz);
+    position_scene = view_to_scene_space(position_scene);
+    position_scene = position_scene + cameraPosition;
+    position_scene = position_scene - cameraPosition;
+
+    tint.a = 1.0;
+
+    if (material_mask == 62u) {
+        position_tangent = (position_scene - gbufferModelViewInverse[3].xyz) * tbn;
+        vec2 uv_minus_mid = uv - mc_midTexCoord;
+        atlas_tile_offset = min(uv, mc_midTexCoord - uv_minus_mid);
+        atlas_tile_scale = abs(uv_minus_mid) * 2.0;
+        atlas_tile_coord = sign(uv_minus_mid) * 0.5 + 0.5;
+    }
+
+    if (dot(position_scene, tbn[2]) > 0.0) tbn[2] = -tbn[2];
+
+#if defined WORLD_NETHER
+    fog_params = get_fog_parameters(get_weather());
+#endif
+
+    position_view = scene_to_view_space(position_scene);
+    vec4 position_clip = project(gl_ProjectionMatrix, position_view);
+
+#if defined TAA && defined TAAU
+    position_clip.xy  = position_clip.xy * taau_render_scale + position_clip.w * (taau_render_scale - 1.0);
+    position_clip.xy += taa_offset * position_clip.w;
+#elif defined TAA
+    position_clip.xy += taa_offset * position_clip.w * 0.66;
+#endif
+
+    gl_Position = position_clip;
+}

--- a/shaders/world-1/physics_ocean_shadow.fsh
+++ b/shaders/world-1/physics_ocean_shadow.fsh
@@ -1,0 +1,19 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean_shadow.fsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define fsh
+
+#include "/program/shadow.fsh"

--- a/shaders/world-1/physics_ocean_shadow.vsh
+++ b/shaders/world-1/physics_ocean_shadow.vsh
@@ -1,0 +1,146 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean_shadow.vsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#extension GL_ARB_shader_image_load_store : enable
+#define WORLD_NETHER
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define vsh
+
+#include "/include/global.glsl"
+
+out vec2 uv;
+flat out uint material_mask;
+flat out vec3 tint;
+
+#ifdef WATER_CAUSTICS
+out vec3 scene_pos;
+#endif
+
+attribute vec3 at_midBlock;
+attribute vec4 at_tangent;
+attribute vec3 mc_Entity;
+attribute vec2 mc_midTexCoord;
+
+uniform sampler2D tex;
+uniform sampler2D noisetex;
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+
+uniform vec3 cameraPosition;
+uniform float near;
+uniform float far;
+uniform float frameTimeCounter;
+uniform float rainStrength;
+uniform float wetness;
+uniform vec2 taa_offset;
+uniform vec3 light_dir;
+uniform float world_age;
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+uniform float biome_temperature;
+uniform float biome_humidity;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform sampler2D physics_waviness;
+
+// Physics Mod constants
+const int PHYSICS_ITERATIONS_OFFSET = 13;
+const float PHYSICS_DRAG_MULT = 0.048;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+
+float physics_waveHeight(vec2 position, int iterations, float factor, float time) {
+    position = (position - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    
+    for (int i = 0; i < iterations; i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, position) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        position -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    return height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+}
+
+#include "/include/lighting/shadows/distortion.glsl"
+
+void main() {
+    uv            = gl_MultiTexCoord0.xy;
+    material_mask = uint(mc_Entity.x - 10000.0);
+    tint          = gl_Color.rgb;
+
+#if defined WORLD_NETHER
+    gl_Position = vec4(-1.0);
+    return;
+#endif
+
+    // Physics Mod wave calculation
+    float physics_localWaviness = texelFetch(physics_waviness, ivec2(gl_Vertex.xz) - physics_textureOffset, 0).r;
+    
+    vec4 physics_vertex = vec4(
+        gl_Vertex.x,
+        gl_Vertex.y + physics_waveHeight(gl_Vertex.xz, PHYSICS_ITERATIONS_OFFSET, physics_localWaviness, physics_gameTime),
+        gl_Vertex.z,
+        gl_Vertex.w
+    );
+
+    vec3 pos = transform(gl_ModelViewMatrix, physics_vertex.xyz);
+    pos = transform(shadowModelViewInverse, pos);
+
+    #ifdef WATER_CAUSTICS
+    scene_pos = pos;
+    #endif
+
+    pos = transform(shadowModelView, pos);
+
+    vec3 shadow_clip_pos = project_ortho(gl_ProjectionMatrix, pos);
+    shadow_clip_pos = distort_shadow_space(shadow_clip_pos);
+
+    gl_Position = vec4(shadow_clip_pos, 1.0);
+}

--- a/shaders/world0/clrwl_gbuffers.fsh
+++ b/shaders/world0/clrwl_gbuffers.fsh
@@ -1,8 +1,8 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (Overworld gbuffers)
+ * Colorwheel will find this file and inject clrwl_computeFragment().
+ */
+
 #define WORLD_OVERWORLD
-#define PROGRAM_GBUFFERS_TERRAIN
-#define PROGRAM_GBUFFERS_BLOCK
-#define PROGRAM_GBUFFERS_ENTITIES
-#define COLORWHEEL
 #define fsh
-#include "/program/gbuffers_all_solid.fsh"
+#include "/program/clrwl_gbuffers.fsh"

--- a/shaders/world0/clrwl_gbuffers.vsh
+++ b/shaders/world0/clrwl_gbuffers.vsh
@@ -1,8 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (Overworld gbuffers)
+ */
+
 #define WORLD_OVERWORLD
-#define PROGRAM_GBUFFERS_TERRAIN
-#define PROGRAM_GBUFFERS_BLOCK
-#define PROGRAM_GBUFFERS_ENTITIES
-#define COLORWHEEL
 #define vsh
-#include "/program/gbuffers_all_solid.vsh"
+#include "/program/clrwl_gbuffers.vsh"

--- a/shaders/world0/clrwl_shadow.fsh
+++ b/shaders/world0/clrwl_shadow.fsh
@@ -1,9 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (Overworld shadow)
+ */
+
 #define WORLD_OVERWORLD
-#define PROGRAM_SHADOW
-#define PROGRAM_SHADOW_SOLID
-#define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
-#define COLORWHEEL
 #define fsh
-#include "/program/shadow.fsh"
+#include "/program/clrwl_shadow.fsh"

--- a/shaders/world0/clrwl_shadow.vsh
+++ b/shaders/world0/clrwl_shadow.vsh
@@ -1,9 +1,7 @@
-#version 400 compatibility
-#extension GL_ARB_shader_image_load_store : enable
+/*
+ * Photon - Colorwheel support (Overworld shadow)
+ */
+
 #define WORLD_OVERWORLD
-#define PROGRAM_SHADOW
-#define PROGRAM_SHADOW_SOLID
-#define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
 #define vsh
-#include "/program/shadow.vsh"
+#include "/program/clrwl_shadow.vsh"

--- a/shaders/world0/physics_ocean.fsh
+++ b/shaders/world0/physics_ocean.fsh
@@ -1,0 +1,423 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean.fsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define fsh
+
+#include "/include/global.glsl"
+
+layout (location = 0) out vec4 refraction_data;
+layout (location = 1) out vec4 fragment_color;
+
+/* RENDERTARGETS: 3,13 */
+
+in vec2 uv;
+in vec2 light_levels;
+in vec3 position_view;
+in vec3 position_scene;
+in vec4 tint;
+
+flat in vec3 light_color;
+flat in vec3 ambient_color;
+flat in uint material_mask;
+in mat3 tbn;
+
+in vec2 atlas_tile_coord;
+in vec3 position_tangent;
+flat in vec2 atlas_tile_offset;
+flat in vec2 atlas_tile_scale;
+
+in vec3 physics_localPosition;
+in float physics_localWaviness;
+
+#if defined WORLD_OVERWORLD
+#include "/include/fog/overworld/parameters.glsl"
+flat in OverworldFogParameters fog_params;
+#endif
+
+uniform sampler2D noisetex;
+uniform sampler2D gtexture;
+uniform sampler2D normals;
+uniform sampler2D specular;
+uniform sampler2D colortex4;
+uniform sampler2D colortex5;
+uniform sampler2D colortex7;
+
+#ifdef CLOUD_SHADOWS
+uniform sampler2D colortex8;
+#endif
+
+uniform sampler2D depthtex1;
+
+#ifdef COLORED_LIGHTS
+uniform sampler3D light_sampler_a;
+uniform sampler3D light_sampler_b;
+#endif
+
+#ifdef SHADOW
+uniform sampler2D shadowtex0;
+uniform sampler2DShadow shadowtex1;
+#endif
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferPreviousModelView;
+uniform mat4 gbufferPreviousProjection;
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+uniform mat4 shadowProjection;
+uniform mat4 shadowProjectionInverse;
+
+uniform vec3 cameraPosition;
+uniform vec3 previousCameraPosition;
+
+uniform float near;
+uniform float far;
+uniform float frameTimeCounter;
+uniform float sunAngle;
+uniform float rainStrength;
+uniform float wetness;
+
+uniform int worldTime;
+uniform int moonPhase;
+uniform int frameCounter;
+uniform int isEyeInWater;
+
+uniform float blindness;
+uniform float nightVision;
+uniform float darknessFactor;
+uniform float eyeAltitude;
+
+uniform vec3 light_dir;
+uniform vec3 sun_dir;
+uniform vec3 moon_dir;
+
+uniform vec2 view_res;
+uniform vec2 view_pixel_size;
+uniform vec2 taa_offset;
+
+uniform float eye_skylight;
+uniform float biome_cave;
+uniform float biome_may_rain;
+uniform float biome_may_snow;
+
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_globalTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform vec3 physics_modelOffset;
+uniform float physics_rippleRange;
+uniform float physics_foamAmount;
+uniform float physics_foamOpacity;
+uniform sampler2D physics_waviness;
+uniform sampler2D physics_ripples;
+uniform sampler3D physics_foam;
+
+// Physics Mod constants
+const float PHYSICS_NORMAL_STRENGTH = 1.4;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_W_DETAIL = 0.75;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+const float PHYSICS_DRAG_MULT = 0.048;
+
+vec3 physics_waveNormal(const in vec2 position, const in vec2 direction, const in float factor, const in float time) {
+    float oceanHeightFactor = physics_oceanHeight / 13.0;
+    float totalFactor = oceanHeightFactor * factor;
+    vec3 waveNormal = normalize(vec3(direction.x * totalFactor, PHYSICS_NORMAL_STRENGTH, direction.y * totalFactor));
+    
+    vec2 eyePosition = position + physics_modelOffset.xz;
+    vec2 rippleFetch = (eyePosition + vec2(physics_rippleRange)) / (physics_rippleRange * 2.0);
+    vec2 rippleTexelSize = vec2(2.0 / textureSize(physics_ripples, 0).x, 0.0);
+    float left = texture(physics_ripples, rippleFetch - rippleTexelSize.xy).r;
+    float right = texture(physics_ripples, rippleFetch + rippleTexelSize.xy).r;
+    float top = texture(physics_ripples, rippleFetch - rippleTexelSize.yx).r;
+    float bottom = texture(physics_ripples, rippleFetch + rippleTexelSize.yx).r;
+    float totalEffect = left + right + top + bottom;
+    
+    float normalx = left - right;
+    float normalz = top - bottom;
+    vec3 rippleNormal = normalize(vec3(normalx, 1.0, normalz));
+    return normalize(mix(waveNormal, rippleNormal, pow(totalEffect, 0.5)));
+}
+
+struct WavePixelData {
+    vec2 direction;
+    vec2 worldPos;
+    vec3 normal;
+    float foam;
+    float height;
+};
+
+WavePixelData physics_wavePixel(const in vec2 position, const in float factor, const in float iterations, const in float time) {
+    vec2 wavePos = (position.xy - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    vec2 dx = vec2(0.0);
+    
+    for (int i = 0; i < int(iterations); i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, wavePos) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        dx += force / pow(weight, PHYSICS_W_DETAIL);
+        wavePos -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    WavePixelData data;
+    data.direction = -vec2(dx / pow(waveSum, 1.0 - PHYSICS_W_DETAIL));
+    data.worldPos = wavePos / physics_oceanWaveHorizontalScale / PHYSICS_XZ_SCALE;
+    data.height = height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+    
+    data.normal = physics_waveNormal(position, data.direction, factor, time);
+
+    float waveAmplitude = data.height * pow(max(data.normal.y, 0.0), 4.0);
+    vec2 waterUV = mix(position - physics_waveOffset, data.worldPos, clamp(factor * 2.0, 0.2, 1.0));
+    
+    vec2 s1 = textureLod(physics_foam, vec3(waterUV * 0.26, physics_globalTime / 360.0), 0).rg;
+    vec2 s2 = textureLod(physics_foam, vec3(waterUV * 0.02, physics_globalTime / 360.0 + 0.5), 0).rg;
+    vec2 s3 = textureLod(physics_foam, vec3(waterUV * 0.1, physics_globalTime / 360.0 + 1.0), 0).rg;
+    
+    float waterSurfaceNoise = s1.r * s2.r * s3.r * 2.8 * physics_foamAmount;
+    waveAmplitude = clamp(waveAmplitude * 1.2, 0.0, 1.0);
+    waterSurfaceNoise = (1.0 - waveAmplitude) * waterSurfaceNoise + waveAmplitude * physics_foamAmount;
+    
+    float worleyNoise = 0.2 + 0.8 * s1.g * (1.0 - s2.g);
+    float waterFoamMinSmooth = 0.45;
+    float waterFoamMaxSmooth = 2.0;
+    waterSurfaceNoise = smoothstep(waterFoamMinSmooth, 1.0, waterSurfaceNoise) * worleyNoise;
+    
+    data.foam = clamp(waterFoamMaxSmooth * waterSurfaceNoise * physics_foamOpacity, 0.0, 1.0);
+    
+    return data;
+}
+
+#define TEMPORAL_REPROJECTION
+
+#ifdef SHADOW_COLOR
+    #undef SHADOW_COLOR
+#endif
+
+#ifdef DIRECTIONAL_LIGHTMAPS
+#include "/include/lighting/directional_lightmaps.glsl"
+#endif
+
+#include "/include/fog/simple_fog.glsl"
+#include "/include/lighting/diffuse_lighting.glsl"
+
+#include "/include/lighting/shadows/pcss.glsl"
+#include "/include/lighting/specular_lighting.glsl"
+#include "/include/misc/lod_mod_support.glsl"
+#include "/include/surface/material.glsl"
+#include "/include/misc/material_masks.glsl"
+#include "/include/misc/purkinje_shift.glsl"
+#include "/include/surface/water_normal.glsl"
+#include "/include/utility/color.glsl"
+#include "/include/utility/encoding.glsl"
+#include "/include/utility/fast_math.glsl"
+#include "/include/utility/space_conversion.glsl"
+
+#ifdef CLOUD_SHADOWS
+#include "/include/lighting/cloud_shadows.glsl"
+#endif
+
+const float lod_bias = log2(taau_render_scale);
+
+Material get_water_material_physics(vec3 direction_world, vec3 normal, float layer_dist, float foam, out float alpha) {
+    Material material = water_material;
+    alpha = 0.01;
+
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT || WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    vec4 base_color = texture(gtexture, uv, lod_bias);
+    float texture_highlight = dampen(0.5 * sqr(linear_step(0.63, 1.0, base_color.r)) + 0.03 * base_color.r);
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    texture_highlight *= 1.0 - cube(linear_step(0.0, 0.5, light_levels.y));
+#endif
+    material.albedo = clamp01(0.5 * exp(-2.0 * water_absorption_coeff) * texture_highlight);
+    material.roughness += 0.3 * texture_highlight;
+    alpha += texture_highlight;
+#elif WATER_TEXTURE == WATER_TEXTURE_VANILLA
+    vec4 base_color = texture(gtexture, uv, lod_bias) * tint;
+    material.albedo = srgb_eotf_inv(base_color.rgb * base_color.a) * rec709_to_working_color;
+    alpha = base_color.a;
+#endif
+
+    // Physics Mod foam
+    material.albedo = mix(material.albedo, vec3(1.0), foam * 0.8);
+    alpha = max(alpha, foam);
+
+#ifdef WATER_EDGE_HIGHLIGHT
+    float dist = layer_dist * max(abs(direction_world.y), eps);
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT || WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    float edge_highlight = cube(max0(1.0 - 2.0 * dist)) * (1.0 + 8.0 * texture_highlight);
+#else
+    float edge_highlight = cube(max0(1.0 - 2.0 * dist));
+#endif
+    edge_highlight *= WATER_EDGE_HIGHLIGHT_INTENSITY * max0(normal.y) * (1.0 - 0.5 * sqr(light_levels.y));
+    material.albedo += 0.1 * edge_highlight / mix(1.0, max(dot(ambient_color, luminance_weights_rec2020), 0.5), light_levels.y);
+    material.albedo = clamp01(material.albedo);
+    alpha += edge_highlight;
+#endif
+
+    return material;
+}
+
+vec4 water_absorption_approx_physics(vec4 color, float sss_depth, float layer_dist, float LoV, float NoV, float cloud_shadows) {
+    vec3 biome_water_color = srgb_eotf_inv(tint.rgb) * rec709_to_working_color;
+    vec3 absorption_coeff = biome_water_coeff(biome_water_color);
+    float dist = layer_dist * float(isEyeInWater != 1 || NoV >= 0.0);
+
+    mat2x3 water_fog = water_fog_simple(light_color * cloud_shadows, ambient_color, absorption_coeff, light_levels, dist, -LoV, sss_depth);
+
+    float brightness_control = 1.0 - exp(-0.33 * layer_dist);
+    brightness_control = (1.0 - light_levels.y) + brightness_control * light_levels.y;
+
+    return vec4(color.rgb + water_fog[0] * (1.0 + 6.0 * sqr(water_fog[1])) * brightness_control, 1.0 - water_fog[1].x);
+}
+
+void main() {
+    vec2 coord = gl_FragCoord.xy * view_pixel_size * rcp(taau_render_scale);
+
+#if defined TAA && defined TAAU
+    if (clamp01(coord) != coord) discard;
+#endif
+
+    // Physics Mod wave calculation
+    WavePixelData wave = physics_wavePixel(physics_localPosition.xz, physics_localWaviness, float(physics_iterationsNormal), physics_gameTime);
+    
+    vec3 physics_normal = wave.normal;
+    if (!gl_FrontFacing) physics_normal = -physics_normal;
+
+    float depth0 = gl_FragCoord.z;
+    float depth1 = texelFetch(depthtex1, ivec2(gl_FragCoord.xy), 0).x;
+
+    vec3 world_pos = position_scene + cameraPosition;
+    vec3 direction_world = normalize(position_scene - gbufferModelViewInverse[3].xyz);
+
+    vec3 view_back_pos = screen_to_view_space(vec3(coord, depth1), true);
+
+#ifdef DISTANT_HORIZONS
+    float depth1_dh = texelFetch(dhDepthTex1, ivec2(gl_FragCoord.xy), 0).x;
+    if (is_lod_terrain(depth1, depth1_dh)) {
+        view_back_pos = screen_to_view_space(vec3(coord, depth1_dh), true, true);
+    }
+#endif
+
+    vec3 scene_back_pos = view_to_scene_space(view_back_pos);
+    float layer_dist = distance(position_scene, scene_back_pos);
+
+    Material material;
+    vec3 normal = physics_normal;
+    vec3 normal_tangent = vec3(physics_normal.x, physics_normal.z, physics_normal.y);
+
+    bool is_water = material_mask == MATERIAL_WATER;
+    vec2 adjusted_light_levels = light_levels;
+
+    if (is_water) {
+        material = get_water_material_physics(direction_world, normal, layer_dist, wave.foam, fragment_color.a);
+    } else {
+        fragment_color = texture(gtexture, uv, lod_bias) * tint;
+        if (fragment_color.a < 0.1) { discard; return; }
+        material = material_from(fragment_color.rgb, material_mask, world_pos, tbn[2], adjusted_light_levels);
+    }
+
+    float NoL = dot(normal, light_dir);
+    float NoV = clamp01(dot(normal, -direction_world));
+    float LoV = dot(light_dir, -direction_world);
+    float halfway_norm = inversesqrt(2.0 * LoV + 2.0);
+    float NoH = (NoL + NoV) * halfway_norm;
+    float LoH = LoV * halfway_norm + halfway_norm;
+
+#if defined WORLD_OVERWORLD && defined CLOUD_SHADOWS
+    float cloud_shadows = get_cloud_shadows(colortex8, position_scene);
+#else
+    #define cloud_shadows 1.0
+#endif
+
+#if defined SHADOW && defined WORLD_OVERWORLD
+    float sss_depth;
+    float shadow_distance_fade;
+    vec3 shadows = get_filtered_shadows(position_scene, tbn[2], adjusted_light_levels.y, cloud_shadows, material.sss_amount, shadow_distance_fade, sss_depth);
+#else
+    #define sss_depth 0.0
+    #define shadow_distance_fade 0.0
+    vec3 shadows = vec3(pow8(adjusted_light_levels.y));
+#endif
+
+    fragment_color.rgb = get_diffuse_lighting(
+        material, position_scene, normal, tbn[2], tbn[2], shadows, adjusted_light_levels, 1.0, 0.0, sss_depth,
+#ifdef CLOUD_SHADOWS
+        cloud_shadows,
+#endif
+        shadow_distance_fade, NoL, NoV, NoH, LoV
+    ) * fragment_color.a;
+
+#if defined WORLD_OVERWORLD
+    fragment_color.rgb += get_specular_highlight(material, NoL, NoV, NoH, LoV, LoH) * light_color * shadows * cloud_shadows;
+#endif
+
+#if defined ENVIRONMENT_REFLECTIONS || defined SKY_REFLECTIONS
+    if (material.ssr_multiplier > eps) {
+        vec3 position_screen = vec3(gl_FragCoord.xy * rcp(taau_render_scale) * view_pixel_size, gl_FragCoord.z);
+        mat3 new_tbn = get_tbn_matrix(normal);
+        fragment_color.rgb += get_specular_reflections(material, new_tbn, position_screen, position_view, world_pos, normal, tbn[2], direction_world, direction_world * new_tbn, light_levels.y, is_water);
+    }
+#endif
+
+    if (is_water) {
+        fragment_color = water_absorption_approx_physics(fragment_color, sss_depth, layer_dist, LoV, dot(tbn[2], direction_world), cloud_shadows);
+
+#ifdef SNELLS_WINDOW
+        if (isEyeInWater == 1) {
+            fragment_color.a = mix(fragment_color.a, 1.0, fresnel_dielectric_n(NoV, air_n / water_n).x);
+        }
+#endif
+    }
+
+    vec4 fog = common_fog(length(position_scene), false);
+    fragment_color.rgb = fragment_color.rgb * fog.a + fog.rgb;
+    fragment_color.rgb = purkinje_shift(fragment_color.rgb, adjusted_light_levels);
+
+    refraction_data.xy = split_2x8(normal_tangent.x * 0.5 + 0.5);
+    refraction_data.zw = split_2x8(normal_tangent.y * 0.5 + 0.5);
+}

--- a/shaders/world0/physics_ocean.vsh
+++ b/shaders/world0/physics_ocean.vsh
@@ -1,0 +1,223 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean.vsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define vsh
+
+#include "/include/global.glsl"
+
+out vec2 uv;
+out vec2 light_levels;
+out vec3 position_view;
+out vec3 position_scene;
+out vec4 tint;
+
+flat out vec3 light_color;
+flat out vec3 ambient_color;
+flat out uint material_mask;
+out mat3 tbn;
+
+out vec2 atlas_tile_coord;
+out vec3 position_tangent;
+flat out vec2 atlas_tile_offset;
+flat out vec2 atlas_tile_scale;
+
+out vec3 physics_localPosition;
+out float physics_localWaviness;
+
+#if defined WORLD_OVERWORLD
+#include "/include/fog/overworld/parameters.glsl"
+flat out OverworldFogParameters fog_params;
+#endif
+
+attribute vec4 at_tangent;
+attribute vec3 mc_Entity;
+attribute vec2 mc_midTexCoord;
+
+uniform sampler2D noisetex;
+uniform sampler2D colortex4;
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+
+uniform vec3 cameraPosition;
+uniform float near;
+uniform float far;
+uniform ivec2 atlasSize;
+uniform int renderStage;
+uniform int worldTime;
+uniform int worldDay;
+uniform int frameCounter;
+uniform float frameTimeCounter;
+uniform float sunAngle;
+uniform float rainStrength;
+uniform float wetness;
+uniform vec2 view_res;
+uniform vec2 view_pixel_size;
+uniform vec2 taa_offset;
+uniform vec3 light_dir;
+uniform vec3 sun_dir;
+uniform float eye_skylight;
+
+uniform float biome_temperate;
+uniform float biome_arid;
+uniform float biome_snowy;
+uniform float biome_taiga;
+uniform float biome_jungle;
+uniform float biome_swamp;
+uniform float biome_may_rain;
+uniform float biome_may_snow;
+uniform float biome_temperature;
+uniform float biome_humidity;
+uniform float world_age;
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+uniform float desert_sandstorm;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform vec3 physics_modelOffset;
+uniform sampler2D physics_waviness;
+
+// Physics Mod constants
+const int PHYSICS_ITERATIONS_OFFSET = 13;
+const float PHYSICS_DRAG_MULT = 0.048;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+
+float physics_waveHeight(vec2 position, int iterations, float factor, float time) {
+    position = (position - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    
+    for (int i = 0; i < iterations; i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, position) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        position -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    return height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+}
+
+#include "/include/misc/material_masks.glsl"
+#include "/include/utility/space_conversion.glsl"
+#include "/include/vertex/displacement.glsl"
+
+#if defined WORLD_OVERWORLD
+#include "/include/weather/fog.glsl"
+#endif
+
+uint get_material_mask_physics() {
+    return uint(max(0.0, mc_Entity.x - 10000.0));
+}
+
+mat3 get_tbn_matrix_physics() {
+    mat3 tbn_matrix;
+    tbn_matrix[0] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * at_tangent.xyz);
+    tbn_matrix[2] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * gl_Normal);
+    tbn_matrix[1] = cross(tbn_matrix[0], tbn_matrix[2]) * sign(at_tangent.w);
+    return tbn_matrix;
+}
+
+void main() {
+    uv            = mat2(gl_TextureMatrix[0]) * gl_MultiTexCoord0.xy + gl_TextureMatrix[0][3].xy;
+    light_levels  = clamp01(gl_MultiTexCoord1.xy * rcp(240.0));
+    tint          = gl_Color;
+    material_mask = get_material_mask_physics();
+    tbn           = get_tbn_matrix_physics();
+
+    light_color   = texelFetch(colortex4, ivec2(191, 0), 0).rgb;
+#if defined WORLD_OVERWORLD && defined SH_SKYLIGHT
+    ambient_color = texelFetch(colortex4, ivec2(191, 11), 0).rgb;
+#else
+    ambient_color = texelFetch(colortex4, ivec2(191, 1), 0).rgb;
+#endif
+
+    // Physics Mod wave calculation
+    physics_localWaviness = texelFetch(physics_waviness, ivec2(gl_Vertex.xz) - physics_textureOffset, 0).r;
+    
+    vec4 physics_vertex = vec4(
+        gl_Vertex.x,
+        gl_Vertex.y + physics_waveHeight(gl_Vertex.xz, PHYSICS_ITERATIONS_OFFSET, physics_localWaviness, physics_gameTime),
+        gl_Vertex.z,
+        gl_Vertex.w
+    );
+    
+    physics_localPosition = physics_vertex.xyz;
+
+    bool is_top_vertex = uv.y < mc_midTexCoord.y;
+
+    position_scene = transform(gl_ModelViewMatrix, physics_vertex.xyz);
+    position_scene = view_to_scene_space(position_scene);
+    position_scene = position_scene + cameraPosition;
+    position_scene = position_scene - cameraPosition;
+
+    tint.a = 1.0;
+
+    if (material_mask == 62u) {
+        position_tangent = (position_scene - gbufferModelViewInverse[3].xyz) * tbn;
+        vec2 uv_minus_mid = uv - mc_midTexCoord;
+        atlas_tile_offset = min(uv, mc_midTexCoord - uv_minus_mid);
+        atlas_tile_scale = abs(uv_minus_mid) * 2.0;
+        atlas_tile_coord = sign(uv_minus_mid) * 0.5 + 0.5;
+    }
+
+    if (dot(position_scene, tbn[2]) > 0.0) tbn[2] = -tbn[2];
+
+#if defined WORLD_OVERWORLD
+    fog_params = get_fog_parameters(get_weather());
+#endif
+
+    position_view = scene_to_view_space(position_scene);
+    vec4 position_clip = project(gl_ProjectionMatrix, position_view);
+
+#if defined TAA && defined TAAU
+    position_clip.xy  = position_clip.xy * taau_render_scale + position_clip.w * (taau_render_scale - 1.0);
+    position_clip.xy += taa_offset * position_clip.w;
+#elif defined TAA
+    position_clip.xy += taa_offset * position_clip.w * 0.66;
+#endif
+
+    gl_Position = position_clip;
+}

--- a/shaders/world0/physics_ocean_shadow.fsh
+++ b/shaders/world0/physics_ocean_shadow.fsh
@@ -1,0 +1,19 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean_shadow.fsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define fsh
+
+#include "/program/shadow.fsh"

--- a/shaders/world0/physics_ocean_shadow.vsh
+++ b/shaders/world0/physics_ocean_shadow.vsh
@@ -1,0 +1,146 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean_shadow.vsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#extension GL_ARB_shader_image_load_store : enable
+#define WORLD_OVERWORLD
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define vsh
+
+#include "/include/global.glsl"
+
+out vec2 uv;
+flat out uint material_mask;
+flat out vec3 tint;
+
+#ifdef WATER_CAUSTICS
+out vec3 scene_pos;
+#endif
+
+attribute vec3 at_midBlock;
+attribute vec4 at_tangent;
+attribute vec3 mc_Entity;
+attribute vec2 mc_midTexCoord;
+
+uniform sampler2D tex;
+uniform sampler2D noisetex;
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+
+uniform vec3 cameraPosition;
+uniform float near;
+uniform float far;
+uniform float frameTimeCounter;
+uniform float rainStrength;
+uniform float wetness;
+uniform vec2 taa_offset;
+uniform vec3 light_dir;
+uniform float world_age;
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+uniform float biome_temperature;
+uniform float biome_humidity;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform sampler2D physics_waviness;
+
+// Physics Mod constants
+const int PHYSICS_ITERATIONS_OFFSET = 13;
+const float PHYSICS_DRAG_MULT = 0.048;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+
+float physics_waveHeight(vec2 position, int iterations, float factor, float time) {
+    position = (position - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    
+    for (int i = 0; i < iterations; i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, position) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        position -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    return height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+}
+
+#include "/include/lighting/shadows/distortion.glsl"
+
+void main() {
+    uv            = gl_MultiTexCoord0.xy;
+    material_mask = uint(mc_Entity.x - 10000.0);
+    tint          = gl_Color.rgb;
+
+#if defined WORLD_NETHER
+    gl_Position = vec4(-1.0);
+    return;
+#endif
+
+    // Physics Mod wave calculation
+    float physics_localWaviness = texelFetch(physics_waviness, ivec2(gl_Vertex.xz) - physics_textureOffset, 0).r;
+    
+    vec4 physics_vertex = vec4(
+        gl_Vertex.x,
+        gl_Vertex.y + physics_waveHeight(gl_Vertex.xz, PHYSICS_ITERATIONS_OFFSET, physics_localWaviness, physics_gameTime),
+        gl_Vertex.z,
+        gl_Vertex.w
+    );
+
+    vec3 pos = transform(gl_ModelViewMatrix, physics_vertex.xyz);
+    pos = transform(shadowModelViewInverse, pos);
+
+    #ifdef WATER_CAUSTICS
+    scene_pos = pos;
+    #endif
+
+    pos = transform(shadowModelView, pos);
+
+    vec3 shadow_clip_pos = project_ortho(gl_ProjectionMatrix, pos);
+    shadow_clip_pos = distort_shadow_space(shadow_clip_pos);
+
+    gl_Position = vec4(shadow_clip_pos, 1.0);
+}

--- a/shaders/world1/clrwl_gbuffers.fsh
+++ b/shaders/world1/clrwl_gbuffers.fsh
@@ -1,8 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (End gbuffers)
+ */
+
 #define WORLD_END
-#define PROGRAM_GBUFFERS_TERRAIN
-#define PROGRAM_GBUFFERS_BLOCK
-#define PROGRAM_GBUFFERS_ENTITIES
-#define COLORWHEEL
 #define fsh
-#include "/program/gbuffers_all_solid.fsh"
+#include "/program/clrwl_gbuffers.fsh"

--- a/shaders/world1/clrwl_gbuffers.vsh
+++ b/shaders/world1/clrwl_gbuffers.vsh
@@ -1,8 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (End gbuffers)
+ */
+
 #define WORLD_END
-#define PROGRAM_GBUFFERS_TERRAIN
-#define PROGRAM_GBUFFERS_BLOCK
-#define PROGRAM_GBUFFERS_ENTITIES
-#define COLORWHEEL
 #define vsh
-#include "/program/gbuffers_all_solid.vsh"
+#include "/program/clrwl_gbuffers.vsh"

--- a/shaders/world1/clrwl_shadow.fsh
+++ b/shaders/world1/clrwl_shadow.fsh
@@ -1,9 +1,7 @@
-#version 400 compatibility
+/*
+ * Photon - Colorwheel support (End shadow)
+ */
+
 #define WORLD_END
-#define PROGRAM_SHADOW
-#define PROGRAM_SHADOW_SOLID
-#define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
-#define COLORWHEEL
 #define fsh
-#include "/program/shadow.fsh"
+#include "/program/clrwl_shadow.fsh"

--- a/shaders/world1/clrwl_shadow.vsh
+++ b/shaders/world1/clrwl_shadow.vsh
@@ -1,9 +1,7 @@
-#version 400 compatibility
-#extension GL_ARB_shader_image_load_store : enable
+/*
+ * Photon - Colorwheel support (End shadow)
+ */
+
 #define WORLD_END
-#define PROGRAM_SHADOW
-#define PROGRAM_SHADOW_SOLID
-#define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
 #define vsh
-#include "/program/shadow.vsh"
+#include "/program/clrwl_shadow.vsh"

--- a/shaders/world1/physics_ocean.fsh
+++ b/shaders/world1/physics_ocean.fsh
@@ -1,0 +1,423 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean.fsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define fsh
+
+#include "/include/global.glsl"
+
+layout (location = 0) out vec4 refraction_data;
+layout (location = 1) out vec4 fragment_color;
+
+/* RENDERTARGETS: 3,13 */
+
+in vec2 uv;
+in vec2 light_levels;
+in vec3 position_view;
+in vec3 position_scene;
+in vec4 tint;
+
+flat in vec3 light_color;
+flat in vec3 ambient_color;
+flat in uint material_mask;
+in mat3 tbn;
+
+in vec2 atlas_tile_coord;
+in vec3 position_tangent;
+flat in vec2 atlas_tile_offset;
+flat in vec2 atlas_tile_scale;
+
+in vec3 physics_localPosition;
+in float physics_localWaviness;
+
+#if defined WORLD_END
+#include "/include/fog/overworld/parameters.glsl"
+flat in OverworldFogParameters fog_params;
+#endif
+
+uniform sampler2D noisetex;
+uniform sampler2D gtexture;
+uniform sampler2D normals;
+uniform sampler2D specular;
+uniform sampler2D colortex4;
+uniform sampler2D colortex5;
+uniform sampler2D colortex7;
+
+#ifdef CLOUD_SHADOWS
+uniform sampler2D colortex8;
+#endif
+
+uniform sampler2D depthtex1;
+
+#ifdef COLORED_LIGHTS
+uniform sampler3D light_sampler_a;
+uniform sampler3D light_sampler_b;
+#endif
+
+#ifdef SHADOW
+uniform sampler2D shadowtex0;
+uniform sampler2DShadow shadowtex1;
+#endif
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 gbufferPreviousModelView;
+uniform mat4 gbufferPreviousProjection;
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+uniform mat4 shadowProjection;
+uniform mat4 shadowProjectionInverse;
+
+uniform vec3 cameraPosition;
+uniform vec3 previousCameraPosition;
+
+uniform float near;
+uniform float far;
+uniform float frameTimeCounter;
+uniform float sunAngle;
+uniform float rainStrength;
+uniform float wetness;
+
+uniform int worldTime;
+uniform int moonPhase;
+uniform int frameCounter;
+uniform int isEyeInWater;
+
+uniform float blindness;
+uniform float nightVision;
+uniform float darknessFactor;
+uniform float eyeAltitude;
+
+uniform vec3 light_dir;
+uniform vec3 sun_dir;
+uniform vec3 moon_dir;
+
+uniform vec2 view_res;
+uniform vec2 view_pixel_size;
+uniform vec2 taa_offset;
+
+uniform float eye_skylight;
+uniform float biome_cave;
+uniform float biome_may_rain;
+uniform float biome_may_snow;
+
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_globalTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform vec3 physics_modelOffset;
+uniform float physics_rippleRange;
+uniform float physics_foamAmount;
+uniform float physics_foamOpacity;
+uniform sampler2D physics_waviness;
+uniform sampler2D physics_ripples;
+uniform sampler3D physics_foam;
+
+// Physics Mod constants
+const float PHYSICS_NORMAL_STRENGTH = 1.4;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_W_DETAIL = 0.75;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+const float PHYSICS_DRAG_MULT = 0.048;
+
+vec3 physics_waveNormal(const in vec2 position, const in vec2 direction, const in float factor, const in float time) {
+    float oceanHeightFactor = physics_oceanHeight / 13.0;
+    float totalFactor = oceanHeightFactor * factor;
+    vec3 waveNormal = normalize(vec3(direction.x * totalFactor, PHYSICS_NORMAL_STRENGTH, direction.y * totalFactor));
+    
+    vec2 eyePosition = position + physics_modelOffset.xz;
+    vec2 rippleFetch = (eyePosition + vec2(physics_rippleRange)) / (physics_rippleRange * 2.0);
+    vec2 rippleTexelSize = vec2(2.0 / textureSize(physics_ripples, 0).x, 0.0);
+    float left = texture(physics_ripples, rippleFetch - rippleTexelSize.xy).r;
+    float right = texture(physics_ripples, rippleFetch + rippleTexelSize.xy).r;
+    float top = texture(physics_ripples, rippleFetch - rippleTexelSize.yx).r;
+    float bottom = texture(physics_ripples, rippleFetch + rippleTexelSize.yx).r;
+    float totalEffect = left + right + top + bottom;
+    
+    float normalx = left - right;
+    float normalz = top - bottom;
+    vec3 rippleNormal = normalize(vec3(normalx, 1.0, normalz));
+    return normalize(mix(waveNormal, rippleNormal, pow(totalEffect, 0.5)));
+}
+
+struct WavePixelData {
+    vec2 direction;
+    vec2 worldPos;
+    vec3 normal;
+    float foam;
+    float height;
+};
+
+WavePixelData physics_wavePixel(const in vec2 position, const in float factor, const in float iterations, const in float time) {
+    vec2 wavePos = (position.xy - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    vec2 dx = vec2(0.0);
+    
+    for (int i = 0; i < int(iterations); i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, wavePos) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        dx += force / pow(weight, PHYSICS_W_DETAIL);
+        wavePos -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    WavePixelData data;
+    data.direction = -vec2(dx / pow(waveSum, 1.0 - PHYSICS_W_DETAIL));
+    data.worldPos = wavePos / physics_oceanWaveHorizontalScale / PHYSICS_XZ_SCALE;
+    data.height = height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+    
+    data.normal = physics_waveNormal(position, data.direction, factor, time);
+
+    float waveAmplitude = data.height * pow(max(data.normal.y, 0.0), 4.0);
+    vec2 waterUV = mix(position - physics_waveOffset, data.worldPos, clamp(factor * 2.0, 0.2, 1.0));
+    
+    vec2 s1 = textureLod(physics_foam, vec3(waterUV * 0.26, physics_globalTime / 360.0), 0).rg;
+    vec2 s2 = textureLod(physics_foam, vec3(waterUV * 0.02, physics_globalTime / 360.0 + 0.5), 0).rg;
+    vec2 s3 = textureLod(physics_foam, vec3(waterUV * 0.1, physics_globalTime / 360.0 + 1.0), 0).rg;
+    
+    float waterSurfaceNoise = s1.r * s2.r * s3.r * 2.8 * physics_foamAmount;
+    waveAmplitude = clamp(waveAmplitude * 1.2, 0.0, 1.0);
+    waterSurfaceNoise = (1.0 - waveAmplitude) * waterSurfaceNoise + waveAmplitude * physics_foamAmount;
+    
+    float worleyNoise = 0.2 + 0.8 * s1.g * (1.0 - s2.g);
+    float waterFoamMinSmooth = 0.45;
+    float waterFoamMaxSmooth = 2.0;
+    waterSurfaceNoise = smoothstep(waterFoamMinSmooth, 1.0, waterSurfaceNoise) * worleyNoise;
+    
+    data.foam = clamp(waterFoamMaxSmooth * waterSurfaceNoise * physics_foamOpacity, 0.0, 1.0);
+    
+    return data;
+}
+
+#define TEMPORAL_REPROJECTION
+
+#ifdef SHADOW_COLOR
+    #undef SHADOW_COLOR
+#endif
+
+#ifdef DIRECTIONAL_LIGHTMAPS
+#include "/include/lighting/directional_lightmaps.glsl"
+#endif
+
+#include "/include/fog/simple_fog.glsl"
+#include "/include/lighting/diffuse_lighting.glsl"
+
+#include "/include/lighting/shadows/pcss.glsl"
+#include "/include/lighting/specular_lighting.glsl"
+#include "/include/misc/lod_mod_support.glsl"
+#include "/include/surface/material.glsl"
+#include "/include/misc/material_masks.glsl"
+#include "/include/misc/purkinje_shift.glsl"
+#include "/include/surface/water_normal.glsl"
+#include "/include/utility/color.glsl"
+#include "/include/utility/encoding.glsl"
+#include "/include/utility/fast_math.glsl"
+#include "/include/utility/space_conversion.glsl"
+
+#ifdef CLOUD_SHADOWS
+#include "/include/lighting/cloud_shadows.glsl"
+#endif
+
+const float lod_bias = log2(taau_render_scale);
+
+Material get_water_material_physics(vec3 direction_world, vec3 normal, float layer_dist, float foam, out float alpha) {
+    Material material = water_material;
+    alpha = 0.01;
+
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT || WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    vec4 base_color = texture(gtexture, uv, lod_bias);
+    float texture_highlight = dampen(0.5 * sqr(linear_step(0.63, 1.0, base_color.r)) + 0.03 * base_color.r);
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    texture_highlight *= 1.0 - cube(linear_step(0.0, 0.5, light_levels.y));
+#endif
+    material.albedo = clamp01(0.5 * exp(-2.0 * water_absorption_coeff) * texture_highlight);
+    material.roughness += 0.3 * texture_highlight;
+    alpha += texture_highlight;
+#elif WATER_TEXTURE == WATER_TEXTURE_VANILLA
+    vec4 base_color = texture(gtexture, uv, lod_bias) * tint;
+    material.albedo = srgb_eotf_inv(base_color.rgb * base_color.a) * rec709_to_working_color;
+    alpha = base_color.a;
+#endif
+
+    // Physics Mod foam
+    material.albedo = mix(material.albedo, vec3(1.0), foam * 0.8);
+    alpha = max(alpha, foam);
+
+#ifdef WATER_EDGE_HIGHLIGHT
+    float dist = layer_dist * max(abs(direction_world.y), eps);
+#if WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT || WATER_TEXTURE == WATER_TEXTURE_HIGHLIGHT_UNDERGROUND
+    float edge_highlight = cube(max0(1.0 - 2.0 * dist)) * (1.0 + 8.0 * texture_highlight);
+#else
+    float edge_highlight = cube(max0(1.0 - 2.0 * dist));
+#endif
+    edge_highlight *= WATER_EDGE_HIGHLIGHT_INTENSITY * max0(normal.y) * (1.0 - 0.5 * sqr(light_levels.y));
+    material.albedo += 0.1 * edge_highlight / mix(1.0, max(dot(ambient_color, luminance_weights_rec2020), 0.5), light_levels.y);
+    material.albedo = clamp01(material.albedo);
+    alpha += edge_highlight;
+#endif
+
+    return material;
+}
+
+vec4 water_absorption_approx_physics(vec4 color, float sss_depth, float layer_dist, float LoV, float NoV, float cloud_shadows) {
+    vec3 biome_water_color = srgb_eotf_inv(tint.rgb) * rec709_to_working_color;
+    vec3 absorption_coeff = biome_water_coeff(biome_water_color);
+    float dist = layer_dist * float(isEyeInWater != 1 || NoV >= 0.0);
+
+    mat2x3 water_fog = water_fog_simple(light_color * cloud_shadows, ambient_color, absorption_coeff, light_levels, dist, -LoV, sss_depth);
+
+    float brightness_control = 1.0 - exp(-0.33 * layer_dist);
+    brightness_control = (1.0 - light_levels.y) + brightness_control * light_levels.y;
+
+    return vec4(color.rgb + water_fog[0] * (1.0 + 6.0 * sqr(water_fog[1])) * brightness_control, 1.0 - water_fog[1].x);
+}
+
+void main() {
+    vec2 coord = gl_FragCoord.xy * view_pixel_size * rcp(taau_render_scale);
+
+#if defined TAA && defined TAAU
+    if (clamp01(coord) != coord) discard;
+#endif
+
+    // Physics Mod wave calculation
+    WavePixelData wave = physics_wavePixel(physics_localPosition.xz, physics_localWaviness, float(physics_iterationsNormal), physics_gameTime);
+    
+    vec3 physics_normal = wave.normal;
+    if (!gl_FrontFacing) physics_normal = -physics_normal;
+
+    float depth0 = gl_FragCoord.z;
+    float depth1 = texelFetch(depthtex1, ivec2(gl_FragCoord.xy), 0).x;
+
+    vec3 world_pos = position_scene + cameraPosition;
+    vec3 direction_world = normalize(position_scene - gbufferModelViewInverse[3].xyz);
+
+    vec3 view_back_pos = screen_to_view_space(vec3(coord, depth1), true);
+
+#ifdef DISTANT_HORIZONS
+    float depth1_dh = texelFetch(dhDepthTex1, ivec2(gl_FragCoord.xy), 0).x;
+    if (is_lod_terrain(depth1, depth1_dh)) {
+        view_back_pos = screen_to_view_space(vec3(coord, depth1_dh), true, true);
+    }
+#endif
+
+    vec3 scene_back_pos = view_to_scene_space(view_back_pos);
+    float layer_dist = distance(position_scene, scene_back_pos);
+
+    Material material;
+    vec3 normal = physics_normal;
+    vec3 normal_tangent = vec3(physics_normal.x, physics_normal.z, physics_normal.y);
+
+    bool is_water = material_mask == MATERIAL_WATER;
+    vec2 adjusted_light_levels = light_levels;
+
+    if (is_water) {
+        material = get_water_material_physics(direction_world, normal, layer_dist, wave.foam, fragment_color.a);
+    } else {
+        fragment_color = texture(gtexture, uv, lod_bias) * tint;
+        if (fragment_color.a < 0.1) { discard; return; }
+        material = material_from(fragment_color.rgb, material_mask, world_pos, tbn[2], adjusted_light_levels);
+    }
+
+    float NoL = dot(normal, light_dir);
+    float NoV = clamp01(dot(normal, -direction_world));
+    float LoV = dot(light_dir, -direction_world);
+    float halfway_norm = inversesqrt(2.0 * LoV + 2.0);
+    float NoH = (NoL + NoV) * halfway_norm;
+    float LoH = LoV * halfway_norm + halfway_norm;
+
+#if defined WORLD_END && defined CLOUD_SHADOWS
+    float cloud_shadows = get_cloud_shadows(colortex8, position_scene);
+#else
+    #define cloud_shadows 1.0
+#endif
+
+#if defined SHADOW && defined WORLD_END
+    float sss_depth;
+    float shadow_distance_fade;
+    vec3 shadows = get_filtered_shadows(position_scene, tbn[2], adjusted_light_levels.y, cloud_shadows, material.sss_amount, shadow_distance_fade, sss_depth);
+#else
+    #define sss_depth 0.0
+    #define shadow_distance_fade 0.0
+    vec3 shadows = vec3(pow8(adjusted_light_levels.y));
+#endif
+
+    fragment_color.rgb = get_diffuse_lighting(
+        material, position_scene, normal, tbn[2], tbn[2], shadows, adjusted_light_levels, 1.0, 0.0, sss_depth,
+#ifdef CLOUD_SHADOWS
+        cloud_shadows,
+#endif
+        shadow_distance_fade, NoL, NoV, NoH, LoV
+    ) * fragment_color.a;
+
+#if defined WORLD_END
+    fragment_color.rgb += get_specular_highlight(material, NoL, NoV, NoH, LoV, LoH) * light_color * shadows * cloud_shadows;
+#endif
+
+#if defined ENVIRONMENT_REFLECTIONS || defined SKY_REFLECTIONS
+    if (material.ssr_multiplier > eps) {
+        vec3 position_screen = vec3(gl_FragCoord.xy * rcp(taau_render_scale) * view_pixel_size, gl_FragCoord.z);
+        mat3 new_tbn = get_tbn_matrix(normal);
+        fragment_color.rgb += get_specular_reflections(material, new_tbn, position_screen, position_view, world_pos, normal, tbn[2], direction_world, direction_world * new_tbn, light_levels.y, is_water);
+    }
+#endif
+
+    if (is_water) {
+        fragment_color = water_absorption_approx_physics(fragment_color, sss_depth, layer_dist, LoV, dot(tbn[2], direction_world), cloud_shadows);
+
+#ifdef SNELLS_WINDOW
+        if (isEyeInWater == 1) {
+            fragment_color.a = mix(fragment_color.a, 1.0, fresnel_dielectric_n(NoV, air_n / water_n).x);
+        }
+#endif
+    }
+
+    vec4 fog = common_fog(length(position_scene), false);
+    fragment_color.rgb = fragment_color.rgb * fog.a + fog.rgb;
+    fragment_color.rgb = purkinje_shift(fragment_color.rgb, adjusted_light_levels);
+
+    refraction_data.xy = split_2x8(normal_tangent.x * 0.5 + 0.5);
+    refraction_data.zw = split_2x8(normal_tangent.y * 0.5 + 0.5);
+}

--- a/shaders/world1/physics_ocean.vsh
+++ b/shaders/world1/physics_ocean.vsh
@@ -1,0 +1,223 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean.vsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define vsh
+
+#include "/include/global.glsl"
+
+out vec2 uv;
+out vec2 light_levels;
+out vec3 position_view;
+out vec3 position_scene;
+out vec4 tint;
+
+flat out vec3 light_color;
+flat out vec3 ambient_color;
+flat out uint material_mask;
+out mat3 tbn;
+
+out vec2 atlas_tile_coord;
+out vec3 position_tangent;
+flat out vec2 atlas_tile_offset;
+flat out vec2 atlas_tile_scale;
+
+out vec3 physics_localPosition;
+out float physics_localWaviness;
+
+#if defined WORLD_END
+#include "/include/fog/overworld/parameters.glsl"
+flat out OverworldFogParameters fog_params;
+#endif
+
+attribute vec4 at_tangent;
+attribute vec3 mc_Entity;
+attribute vec2 mc_midTexCoord;
+
+uniform sampler2D noisetex;
+uniform sampler2D colortex4;
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+
+uniform vec3 cameraPosition;
+uniform float near;
+uniform float far;
+uniform ivec2 atlasSize;
+uniform int renderStage;
+uniform int worldTime;
+uniform int worldDay;
+uniform int frameCounter;
+uniform float frameTimeCounter;
+uniform float sunAngle;
+uniform float rainStrength;
+uniform float wetness;
+uniform vec2 view_res;
+uniform vec2 view_pixel_size;
+uniform vec2 taa_offset;
+uniform vec3 light_dir;
+uniform vec3 sun_dir;
+uniform float eye_skylight;
+
+uniform float biome_temperate;
+uniform float biome_arid;
+uniform float biome_snowy;
+uniform float biome_taiga;
+uniform float biome_jungle;
+uniform float biome_swamp;
+uniform float biome_may_rain;
+uniform float biome_may_snow;
+uniform float biome_temperature;
+uniform float biome_humidity;
+uniform float world_age;
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+uniform float desert_sandstorm;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform vec3 physics_modelOffset;
+uniform sampler2D physics_waviness;
+
+// Physics Mod constants
+const int PHYSICS_ITERATIONS_OFFSET = 13;
+const float PHYSICS_DRAG_MULT = 0.048;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+
+float physics_waveHeight(vec2 position, int iterations, float factor, float time) {
+    position = (position - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    
+    for (int i = 0; i < iterations; i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, position) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        position -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    return height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+}
+
+#include "/include/misc/material_masks.glsl"
+#include "/include/utility/space_conversion.glsl"
+#include "/include/vertex/displacement.glsl"
+
+#if defined WORLD_END
+#include "/include/weather/fog.glsl"
+#endif
+
+uint get_material_mask_physics() {
+    return uint(max(0.0, mc_Entity.x - 10000.0));
+}
+
+mat3 get_tbn_matrix_physics() {
+    mat3 tbn_matrix;
+    tbn_matrix[0] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * at_tangent.xyz);
+    tbn_matrix[2] = mat3(gbufferModelViewInverse) * normalize(gl_NormalMatrix * gl_Normal);
+    tbn_matrix[1] = cross(tbn_matrix[0], tbn_matrix[2]) * sign(at_tangent.w);
+    return tbn_matrix;
+}
+
+void main() {
+    uv            = mat2(gl_TextureMatrix[0]) * gl_MultiTexCoord0.xy + gl_TextureMatrix[0][3].xy;
+    light_levels  = clamp01(gl_MultiTexCoord1.xy * rcp(240.0));
+    tint          = gl_Color;
+    material_mask = get_material_mask_physics();
+    tbn           = get_tbn_matrix_physics();
+
+    light_color   = texelFetch(colortex4, ivec2(191, 0), 0).rgb;
+#if defined WORLD_END && defined SH_SKYLIGHT
+    ambient_color = texelFetch(colortex4, ivec2(191, 11), 0).rgb;
+#else
+    ambient_color = texelFetch(colortex4, ivec2(191, 1), 0).rgb;
+#endif
+
+    // Physics Mod wave calculation
+    physics_localWaviness = texelFetch(physics_waviness, ivec2(gl_Vertex.xz) - physics_textureOffset, 0).r;
+    
+    vec4 physics_vertex = vec4(
+        gl_Vertex.x,
+        gl_Vertex.y + physics_waveHeight(gl_Vertex.xz, PHYSICS_ITERATIONS_OFFSET, physics_localWaviness, physics_gameTime),
+        gl_Vertex.z,
+        gl_Vertex.w
+    );
+    
+    physics_localPosition = physics_vertex.xyz;
+
+    bool is_top_vertex = uv.y < mc_midTexCoord.y;
+
+    position_scene = transform(gl_ModelViewMatrix, physics_vertex.xyz);
+    position_scene = view_to_scene_space(position_scene);
+    position_scene = position_scene + cameraPosition;
+    position_scene = position_scene - cameraPosition;
+
+    tint.a = 1.0;
+
+    if (material_mask == 62u) {
+        position_tangent = (position_scene - gbufferModelViewInverse[3].xyz) * tbn;
+        vec2 uv_minus_mid = uv - mc_midTexCoord;
+        atlas_tile_offset = min(uv, mc_midTexCoord - uv_minus_mid);
+        atlas_tile_scale = abs(uv_minus_mid) * 2.0;
+        atlas_tile_coord = sign(uv_minus_mid) * 0.5 + 0.5;
+    }
+
+    if (dot(position_scene, tbn[2]) > 0.0) tbn[2] = -tbn[2];
+
+#if defined WORLD_END
+    fog_params = get_fog_parameters(get_weather());
+#endif
+
+    position_view = scene_to_view_space(position_scene);
+    vec4 position_clip = project(gl_ProjectionMatrix, position_view);
+
+#if defined TAA && defined TAAU
+    position_clip.xy  = position_clip.xy * taau_render_scale + position_clip.w * (taau_render_scale - 1.0);
+    position_clip.xy += taa_offset * position_clip.w;
+#elif defined TAA
+    position_clip.xy += taa_offset * position_clip.w * 0.66;
+#endif
+
+    gl_Position = position_clip;
+}

--- a/shaders/world1/physics_ocean_shadow.fsh
+++ b/shaders/world1/physics_ocean_shadow.fsh
@@ -1,0 +1,19 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean_shadow.fsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define fsh
+
+#include "/program/shadow.fsh"

--- a/shaders/world1/physics_ocean_shadow.vsh
+++ b/shaders/world1/physics_ocean_shadow.vsh
@@ -1,0 +1,146 @@
+/*
+--------------------------------------------------------------------------------
+
+  Photon Shader by SixthSurge
+  Physics Mod Ocean Support
+
+  world0/physics_ocean_shadow.vsh
+
+--------------------------------------------------------------------------------
+*/
+
+#version 400 compatibility
+#extension GL_ARB_shader_image_load_store : enable
+#define WORLD_END
+#define PROGRAM_SHADOW
+#define PROGRAM_SHADOW_WATER
+#define PHYSICS_OCEAN_SUPPORT
+#define vsh
+
+#include "/include/global.glsl"
+
+out vec2 uv;
+flat out uint material_mask;
+flat out vec3 tint;
+
+#ifdef WATER_CAUSTICS
+out vec3 scene_pos;
+#endif
+
+attribute vec3 at_midBlock;
+attribute vec4 at_tangent;
+attribute vec3 mc_Entity;
+attribute vec2 mc_midTexCoord;
+
+uniform sampler2D tex;
+uniform sampler2D noisetex;
+
+uniform mat4 gbufferModelView;
+uniform mat4 gbufferModelViewInverse;
+uniform mat4 gbufferProjection;
+uniform mat4 gbufferProjectionInverse;
+uniform mat4 shadowModelView;
+uniform mat4 shadowModelViewInverse;
+
+uniform vec3 cameraPosition;
+uniform float near;
+uniform float far;
+uniform float frameTimeCounter;
+uniform float rainStrength;
+uniform float wetness;
+uniform vec2 taa_offset;
+uniform vec3 light_dir;
+uniform float world_age;
+uniform float time_sunrise;
+uniform float time_noon;
+uniform float time_sunset;
+uniform float time_midnight;
+uniform float biome_temperature;
+uniform float biome_humidity;
+
+// Physics Mod uniforms
+uniform int physics_iterationsNormal;
+uniform vec2 physics_waveOffset;
+uniform ivec2 physics_textureOffset;
+uniform float physics_gameTime;
+uniform float physics_oceanHeight;
+uniform float physics_oceanWaveHorizontalScale;
+uniform sampler2D physics_waviness;
+
+// Physics Mod constants
+const int PHYSICS_ITERATIONS_OFFSET = 13;
+const float PHYSICS_DRAG_MULT = 0.048;
+const float PHYSICS_XZ_SCALE = 0.035;
+const float PHYSICS_TIME_MULTIPLICATOR = 0.45;
+const float PHYSICS_FREQUENCY = 6.0;
+const float PHYSICS_SPEED = 2.0;
+const float PHYSICS_WEIGHT = 0.8;
+const float PHYSICS_FREQUENCY_MULT = 1.18;
+const float PHYSICS_SPEED_MULT = 1.07;
+const float PHYSICS_ITER_INC = 12.0;
+
+float physics_waveHeight(vec2 position, int iterations, float factor, float time) {
+    position = (position - physics_waveOffset) * PHYSICS_XZ_SCALE * physics_oceanWaveHorizontalScale;
+    float iter = 0.0;
+    float frequency = PHYSICS_FREQUENCY;
+    float speed = PHYSICS_SPEED;
+    float weight = 1.0;
+    float height = 0.0;
+    float waveSum = 0.0;
+    float modifiedTime = time * PHYSICS_TIME_MULTIPLICATOR;
+    
+    for (int i = 0; i < iterations; i++) {
+        vec2 direction = vec2(sin(iter), cos(iter));
+        float x = dot(direction, position) * frequency + modifiedTime * speed;
+        float wave = exp(sin(x) - 1.0);
+        float result = wave * cos(x);
+        vec2 force = result * weight * direction;
+        
+        position -= force * PHYSICS_DRAG_MULT;
+        height += wave * weight;
+        iter += PHYSICS_ITER_INC;
+        waveSum += weight;
+        weight *= PHYSICS_WEIGHT;
+        frequency *= PHYSICS_FREQUENCY_MULT;
+        speed *= PHYSICS_SPEED_MULT;
+    }
+    
+    return height / waveSum * physics_oceanHeight * factor - physics_oceanHeight * factor * 0.5;
+}
+
+#include "/include/lighting/shadows/distortion.glsl"
+
+void main() {
+    uv            = gl_MultiTexCoord0.xy;
+    material_mask = uint(mc_Entity.x - 10000.0);
+    tint          = gl_Color.rgb;
+
+#if defined WORLD_NETHER
+    gl_Position = vec4(-1.0);
+    return;
+#endif
+
+    // Physics Mod wave calculation
+    float physics_localWaviness = texelFetch(physics_waviness, ivec2(gl_Vertex.xz) - physics_textureOffset, 0).r;
+    
+    vec4 physics_vertex = vec4(
+        gl_Vertex.x,
+        gl_Vertex.y + physics_waveHeight(gl_Vertex.xz, PHYSICS_ITERATIONS_OFFSET, physics_localWaviness, physics_gameTime),
+        gl_Vertex.z,
+        gl_Vertex.w
+    );
+
+    vec3 pos = transform(gl_ModelViewMatrix, physics_vertex.xyz);
+    pos = transform(shadowModelViewInverse, pos);
+
+    #ifdef WATER_CAUSTICS
+    scene_pos = pos;
+    #endif
+
+    pos = transform(shadowModelView, pos);
+
+    vec3 shadow_clip_pos = project_ortho(gl_ProjectionMatrix, pos);
+    shadow_clip_pos = distort_shadow_space(shadow_clip_pos);
+
+    gl_Position = vec4(shadow_clip_pos, 1.0);
+}


### PR DESCRIPTION
Physics Mod ocean support
- Adds `physics_ocean.{vsh,fsh,_shadow.vsh,_shadow.fsh}` for world0, world-1, world1
- Uses PCSS filtering and `is_lod_terrain` / `get_filtered_shadows` for LOD compat
- Registers Physics Mod `customTextures` and `customUniforms` in `shaders.properties`

Colorwheel (Flywheel 1.0) support
- Adds `colorwheel.properties` and `clrwl_gbuffers`/`clrwl_shadow` programs
- Per-world wrappers for world0, world-1, world1
- Enables Flywheel-based mods (e.g. Create) to render with full Photon shading and shadows

Fix: flat tbn interpolation mismatch
Removed `flat` qualifier from `tbn` varying in `gbuffers_all_solid` and `gbuffers_all_translucent`
Prevents GLSL link errors on separate entity draw programs with Iris 1.21.1+