### PR TITLE
Finalize Colorwheel support

### DIFF
--- a/shaders/colorwheel.properties
+++ b/shaders/colorwheel.properties
@@ -1,0 +1,20 @@
+blend.clrwl_gbuffers = off
+blend.clrwl_gbuffers_glint = off
+blend.clrwl_gbuffers_translucent = off
+blend.clrwl_shadow = off
+
+#if MC_VERSION > 12111
+blend.clrwl_gbuffers_glint.colortex13 = ONE ONE ZERO ONE
+#else
+blend.clrwl_gbuffers_glint = off
+blend.clrwl_gbuffers_damagedblock = off
+#endif
+
+blend.clrwl_gbuffers_translucent.colortex13 = ONE ONE_MINUS_SRC_ALPHA ONE ONE_MINUS_SRC_ALPHA
+
+oit = true
+
+oit.gbuffers.coefficientRanks = 3
+
+oit.gbuffers.colortex13 = 0
+oit.gbuffers.colortex13.format = RGBA16F

--- a/shaders/include/lighting/lpv/voxelization.glsl
+++ b/shaders/include/lighting/lpv/voxelization.glsl
@@ -46,6 +46,7 @@ bool is_inside_voxel_volume(vec3 voxel_pos) {
 
 #ifdef PROGRAM_SHADOW
 bool is_voxelized(uint block_id, bool vertex_at_grid_corner) {
+    #if !defined COLORWHEEL
     bool is_terrain = any(equal(
         ivec4(renderStage),
         ivec4(
@@ -55,6 +56,9 @@ bool is_voxelized(uint block_id, bool vertex_at_grid_corner) {
             MC_RENDER_STAGE_TERRAIN_CUTOUT_MIPPED
         )
     ));
+    #else
+    bool is_terrain = true;
+    #endif
 
     bool is_transparent_block = block_id == 1u || // Water
         block_id == 18u || // Transparent metal objects

--- a/shaders/program/gbuffers_all_translucent.fsh
+++ b/shaders/program/gbuffers_all_translucent.fsh
@@ -24,10 +24,15 @@ layout(location = 0) out vec4 fragment_color;
 #endif
 
 in vec2 uv;
-in vec2 light_levels;
 in vec3 position_view;
 in vec3 position_scene;
 in vec4 tint;
+
+#if defined COLORWHEEL
+vec2 light_levels;
+#else
+in vec2 light_levels;
+#endif
 
 flat in uint material_mask;
 flat in mat3 tbn;
@@ -490,7 +495,20 @@ void main() {
     } else {
         // Sample textures
 
+#if defined COLORWHEEL
+        fragment_color = texture(gtexture, uv, lod_bias);
+
+        float ao;
+        vec4 overlayColor;
+
+        clrwl_computeFragment(fragment_color, fragment_color, light_levels, ao, overlayColor);
+        light_levels = clamp((light_levels - 1.0 / 32.0) * 32.0 / 30.0, 0.0, 1.0);
+
+        adjusted_light_levels = light_levels;
+#else
         fragment_color = texture(gtexture, uv, lod_bias) * tint;
+#endif
+
 #ifdef NORMAL_MAPPING
         vec3 normal_map = texture(normals, uv, lod_bias).xyz;
 #endif
@@ -504,7 +522,10 @@ void main() {
         }
 #endif
 
-#if defined PROGRAM_GBUFFERS_ENTITIES_TRANSLUCENT
+#if defined COLORWHEEL
+        fragment_color.rgb =
+            mix(fragment_color.rgb, overlayColor.rgb, overlayColor.a);
+#elif defined PROGRAM_GBUFFERS_ENTITIES_TRANSLUCENT
         // Lightning (old versions)
         if (material_mask == MATERIAL_LIGHTNING_BOLT) {
             fragment_color = vec4(1.0);

--- a/shaders/program/gbuffers_all_translucent.vsh
+++ b/shaders/program/gbuffers_all_translucent.vsh
@@ -13,10 +13,15 @@
 #include "/include/global.glsl"
 
 out vec2 uv;
-out vec2 light_levels;
 out vec3 position_view;
 out vec3 position_scene;
 out vec4 tint;
+
+#if defined COLORWHEEL
+vec2 light_levels;
+#else
+out vec2 light_levels;
+#endif
 
 flat out uint material_mask;
 flat out mat3 tbn;

--- a/shaders/program/gbuffers_armor_glint.fsh
+++ b/shaders/program/gbuffers_armor_glint.fsh
@@ -42,7 +42,19 @@ void main() {
     }
 #endif
 
+#if defined COLORWHEEL
+	vec4 color = texture(gtexture, uv, lod_bias);
+	vec2 lmcoord;
+	float ao;
+	vec4 overlayColor;
+
+	clrwl_computeFragment(color, color, lmcoord, ao, overlayColor);
+	color.rgb = mix(color.rgb, overlayColor.rgb, overlayColor.a);
+    
+	vec3 armor_glint = color.rgb;
+#else
     vec3 armor_glint = texture(gtexture, uv, lod_bias).rgb;
+#endif
 
 #if defined IS_IRIS
     // New overlay handling

--- a/shaders/program/gbuffers_damagedblock.fsh
+++ b/shaders/program/gbuffers_damagedblock.fsh
@@ -43,6 +43,16 @@ void main() {
 #endif
 
     damage_overlay = texture(gtexture, uv, lod_bias);
+
+#if defined COLORWHEEL
+	vec2 lmcoord;
+	float ao;
+	vec4 overlayColor;
+
+	clrwl_computeFragment(damage_overlay, damage_overlay, lmcoord, ao, overlayColor);
+	damage_overlay.rgb = mix(damage_overlay.rgb, overlayColor.rgb, overlayColor.a);
+#endif
+
     if (damage_overlay.a < 0.1) {
         discard;
     }

--- a/shaders/world-1/clrwl_gbuffers_damagedblock.fsh
+++ b/shaders/world-1/clrwl_gbuffers_damagedblock.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_DAMAGEDBLOCK
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_damagedblock.fsh"

--- a/shaders/world-1/clrwl_gbuffers_damagedblock.vsh
+++ b/shaders/world-1/clrwl_gbuffers_damagedblock.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_DAMAGEDBLOCK
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_damagedblock.vsh"

--- a/shaders/world-1/clrwl_gbuffers_glint.fsh
+++ b/shaders/world-1/clrwl_gbuffers_glint.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_ARMOR_GLINT
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_armor_glint.fsh"

--- a/shaders/world-1/clrwl_gbuffers_glint.vsh
+++ b/shaders/world-1/clrwl_gbuffers_glint.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_ARMOR_GLINT
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_armor_glint.vsh"

--- a/shaders/world-1/clrwl_gbuffers_translucent.fsh
+++ b/shaders/world-1/clrwl_gbuffers_translucent.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_WATER
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_all_translucent.fsh"

--- a/shaders/world-1/clrwl_gbuffers_translucent.vsh
+++ b/shaders/world-1/clrwl_gbuffers_translucent.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_NETHER
+#define PROGRAM_GBUFFERS_WATER
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_all_translucent.vsh"

--- a/shaders/world-1/clrwl_shadow.fsh
+++ b/shaders/world-1/clrwl_shadow.fsh
@@ -3,7 +3,6 @@
 #define PROGRAM_SHADOW
 #define PROGRAM_SHADOW_SOLID
 #define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
 #define COLORWHEEL
 #define fsh
 #include "/program/shadow.fsh"

--- a/shaders/world-1/clrwl_shadow.vsh
+++ b/shaders/world-1/clrwl_shadow.vsh
@@ -4,6 +4,6 @@
 #define PROGRAM_SHADOW
 #define PROGRAM_SHADOW_SOLID
 #define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
+#define COLORWHEEL
 #define vsh
 #include "/program/shadow.vsh"

--- a/shaders/world0/clrwl_gbuffers_damagedblock.fsh
+++ b/shaders/world0/clrwl_gbuffers_damagedblock.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_DAMAGEDBLOCK
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_damagedblock.fsh"

--- a/shaders/world0/clrwl_gbuffers_damagedblock.vsh
+++ b/shaders/world0/clrwl_gbuffers_damagedblock.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_DAMAGEDBLOCK
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_damagedblock.vsh"

--- a/shaders/world0/clrwl_gbuffers_glint.fsh
+++ b/shaders/world0/clrwl_gbuffers_glint.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_ARMOR_GLINT
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_armor_glint.fsh"

--- a/shaders/world0/clrwl_gbuffers_glint.vsh
+++ b/shaders/world0/clrwl_gbuffers_glint.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_ARMOR_GLINT
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_armor_glint.vsh"

--- a/shaders/world0/clrwl_gbuffers_translucent.fsh
+++ b/shaders/world0/clrwl_gbuffers_translucent.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_WATER
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_all_translucent.fsh"

--- a/shaders/world0/clrwl_gbuffers_translucent.vsh
+++ b/shaders/world0/clrwl_gbuffers_translucent.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_OVERWORLD
+#define PROGRAM_GBUFFERS_WATER
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_all_translucent.vsh"

--- a/shaders/world0/clrwl_shadow.fsh
+++ b/shaders/world0/clrwl_shadow.fsh
@@ -3,7 +3,6 @@
 #define PROGRAM_SHADOW
 #define PROGRAM_SHADOW_SOLID
 #define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
 #define COLORWHEEL
 #define fsh
 #include "/program/shadow.fsh"

--- a/shaders/world0/clrwl_shadow.vsh
+++ b/shaders/world0/clrwl_shadow.vsh
@@ -4,6 +4,6 @@
 #define PROGRAM_SHADOW
 #define PROGRAM_SHADOW_SOLID
 #define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
+#define COLORWHEEL
 #define vsh
 #include "/program/shadow.vsh"

--- a/shaders/world1/clrwl_gbuffers_damagedblock.fsh
+++ b/shaders/world1/clrwl_gbuffers_damagedblock.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_DAMAGEDBLOCK
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_damagedblock.fsh"

--- a/shaders/world1/clrwl_gbuffers_damagedblock.vsh
+++ b/shaders/world1/clrwl_gbuffers_damagedblock.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_DAMAGEDBLOCK
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_damagedblock.vsh"

--- a/shaders/world1/clrwl_gbuffers_glint.fsh
+++ b/shaders/world1/clrwl_gbuffers_glint.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_ARMOR_GLINT
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_armor_glint.fsh"

--- a/shaders/world1/clrwl_gbuffers_glint.vsh
+++ b/shaders/world1/clrwl_gbuffers_glint.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_ARMOR_GLINT
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_armor_glint.vsh"

--- a/shaders/world1/clrwl_gbuffers_translucent.fsh
+++ b/shaders/world1/clrwl_gbuffers_translucent.fsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_WATER
+#define COLORWHEEL
+#define fsh
+#include "/program/gbuffers_all_translucent.fsh"

--- a/shaders/world1/clrwl_gbuffers_translucent.vsh
+++ b/shaders/world1/clrwl_gbuffers_translucent.vsh
@@ -1,0 +1,6 @@
+#version 400 compatibility
+#define WORLD_END
+#define PROGRAM_GBUFFERS_WATER
+#define COLORWHEEL
+#define vsh
+#include "/program/gbuffers_all_translucent.vsh"

--- a/shaders/world1/clrwl_shadow.fsh
+++ b/shaders/world1/clrwl_shadow.fsh
@@ -3,7 +3,6 @@
 #define PROGRAM_SHADOW
 #define PROGRAM_SHADOW_SOLID
 #define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
 #define COLORWHEEL
 #define fsh
 #include "/program/shadow.fsh"

--- a/shaders/world1/clrwl_shadow.vsh
+++ b/shaders/world1/clrwl_shadow.vsh
@@ -4,6 +4,6 @@
 #define PROGRAM_SHADOW
 #define PROGRAM_SHADOW_SOLID
 #define PROGRAM_SHADOW_BLOCK
-#define PROGRAM_SHADOW_ENTITIES
+#define COLORWHEEL
 #define vsh
 #include "/program/shadow.vsh"


### PR DESCRIPTION
This commit finalize the support of Colorwheel added in #566. I had a fork of photon for some time which supported Colorwheel and voxy, but I forgot to make a pull request (oops).

Compared to #566, this adds:
 - support for translucent, glint and damagedblocks
 - Order Independant Transparency
 - colored lights

Before:
<img width="1920" height="1080" alt="2026-05-01_13 47 27" src="https://github.com/user-attachments/assets/9ee10e51-5285-445c-9be7-04c69b253f67" />
<img width="1920" height="1080" alt="2026-05-01_13 26 40" src="https://github.com/user-attachments/assets/a658cb33-b20e-406d-b4e7-85235ecd5e45" />
<img width="1920" height="1080" alt="2026-05-01_13 31 57" src="https://github.com/user-attachments/assets/744f1397-0bc9-4bb9-aa5e-64bcf8781fa8" />
<img width="1920" height="1080" alt="2026-05-01_13 39 33" src="https://github.com/user-attachments/assets/71df2cd3-0a12-4ade-8e94-728dab6311af" />

After:
<img width="1920" height="1080" alt="2026-05-01_13 47 18" src="https://github.com/user-attachments/assets/6d22947b-6ad6-41bd-a3c9-782e962ac383" />
<img width="1920" height="1080" alt="2026-05-01_13 26 47" src="https://github.com/user-attachments/assets/1ac29664-bd66-49c7-afe8-a15a28192cb9" />
<img width="1920" height="1080" alt="2026-05-01_13 31 46" src="https://github.com/user-attachments/assets/25d0f052-07d7-463c-993a-0d2cdb160689" />
<img width="1920" height="1080" alt="2026-05-01_13 39 27" src="https://github.com/user-attachments/assets/1758f19e-10fe-4ded-950b-57e6f49ca232" />
