### PR TITLE
Fix "0f" causing Voxy programs failing to compile

### DIFF
--- a/shaders/include/lighting/diffuse_lighting.glsl
+++ b/shaders/include/lighting/diffuse_lighting.glsl
@@ -134,7 +134,7 @@ vec3 get_block_lighting(
     float ao,
     float directional_lighting
 ) {
-    vec3 lighting = vec3(0f);
+    vec3 lighting = vec3(0.0f);
 
     float blocklight_falloff
         = get_blocklight_falloff(light_levels.x, light_levels.y, ao);
@@ -167,7 +167,7 @@ vec3 get_sky_lighting(
     float ambient_sss,
     float directional_lighting
 ) {
-    vec3 lighting = vec3(0f);
+    vec3 lighting = vec3(0.0f);
 
 #if defined WORLD_OVERWORLD && defined PROGRAM_DEFERRED4 && defined SH_SKYLIGHT
 #ifdef MC_GL_RENDERER_INTEL
@@ -354,7 +354,7 @@ vec3 get_diffuse_lighting(
 
 #if defined PHOTONICS_DIFFUSE
     if (!is_lod) {
-        vec3 blocklight = vec3(0f);
+        vec3 blocklight = vec3(0.0f);
 
         blocklight += sample_photonics_direct(uv);
 

--- a/shaders/photonics/shader_interface.glsl
+++ b/shaders/photonics/shader_interface.glsl
@@ -22,7 +22,7 @@ uniform vec2 view_pixel_size;
 #include "/include/utility/spherical_harmonics.glsl"
 #endif
 
-vec3 indirect_light_color = vec3(0f);
+vec3 indirect_light_color = vec3(0.0f);
 #define sun_direction light_dir
 
 vec3 load_world_position() {
@@ -76,7 +76,7 @@ vec2 get_taa_jitter() {
 #endif
 
 #else
-    return vec2(0f);
+    return vec2(0.0f);
 #endif
 }
 

--- a/shaders/photonics/shader_interface.glsl
+++ b/shaders/photonics/shader_interface.glsl
@@ -58,7 +58,7 @@ void load_fragment_variables(out vec3 albedo, out vec3 world_pos, out vec3 world
     indirect_light_color = texelFetch(colortex4, ivec2(191, 1), 0).rgb;
 #endif
 #else
-    indirect_light_color = mix(texelFetch(colortex4, ivec2(191, 1), 0).rgb, vec3(1f), 0.5);
+    indirect_light_color = mix(texelFetch(colortex4, ivec2(191, 1), 0).rgb, vec3(1.0f), 0.5);
 #endif
 #endif
 

--- a/shaders/photonics/write_indirect.glsl
+++ b/shaders/photonics/write_indirect.glsl
@@ -1,5 +1,5 @@
 writeonly uniform image2D radiosity_indirect_image;
 
 void write_indirect(vec3 color) {
-    imageStore(radiosity_indirect_image, ivec2(gl_FragCoord.xy), vec4(color, 1f));
+    imageStore(radiosity_indirect_image, ivec2(gl_FragCoord.xy), vec4(color, 1.0f));
 }

--- a/shaders/program/gbuffers_all_solid.fsh
+++ b/shaders/program/gbuffers_all_solid.fsh
@@ -358,7 +358,7 @@ void main() {
 
     gl_FragDepth = screen_pos.z;
 
-    vec4 base_color = vec4(ray.result_color, 1f);
+    vec4 base_color = vec4(ray.result_color, 1.0f);
     vec3 ph_normal = ray.result_normal;
 
 #if defined SPECULAR_MAPPING

--- a/shaders/program/gbuffers_all_solid.fsh
+++ b/shaders/program/gbuffers_all_solid.fsh
@@ -362,7 +362,7 @@ void main() {
     vec3 ph_normal = ray.result_normal;
 
 #if defined SPECULAR_MAPPING
-    vec4 specular_map = vec4(0f);
+    vec4 specular_map = vec4(0.0f);
 #endif
 #endif
 

--- a/shaders/program/shadow_voxels.fsh
+++ b/shaders/program/shadow_voxels.fsh
@@ -32,7 +32,7 @@ void main() {
 
     RayJob ray = RayJob(
         world_pos - world_offset - 0.01f * cage_normal, // Ray origin
-        mat3(shadowModelViewInverse) * vec3(0f, 0f, -1f), // Ray direction
+        mat3(shadowModelViewInverse) * vec3(0.0f, 0.0f, -1.0f), // Ray direction
         vec3(0.0f),
         vec3(0.0f),
         vec3(0.0f),
@@ -46,7 +46,7 @@ void main() {
         discard;
     }
 
-    vec4 base_color = vec4(ray.result_color, 1f);
+    vec4 base_color = vec4(ray.result_color, 1.0f);
 
     shadowcolor0_out = mix(vec3(1.0), base_color.rgb * tint, base_color.a);
     shadowcolor0_out

--- a/shaders/program/shadow_voxels.fsh
+++ b/shaders/program/shadow_voxels.fsh
@@ -33,9 +33,9 @@ void main() {
     RayJob ray = RayJob(
         world_pos - world_offset - 0.01f * cage_normal, // Ray origin
         mat3(shadowModelViewInverse) * vec3(0f, 0f, -1f), // Ray direction
-        vec3(0f),
-        vec3(0f),
-        vec3(0f),
+        vec3(0.0f),
+        vec3(0.0f),
+        vec3(0.0f),
         false
     );
 


### PR DESCRIPTION
Fix #593.
GLSL specification do not allow `0f` as a floating point value as it do not have either decimal point or exponent part , use `0.0f` instead.