### PR TITLE
Fix Voxy blocks removing glint

### DIFF
--- a/shaders/program/c1_blend_layers.fsh
+++ b/shaders/program/c1_blend_layers.fsh
@@ -226,20 +226,6 @@ void main() {
     float front_depth_lod = texelFetch(lod_depth_tex, texel, 0).x;
     float back_depth_lod = texelFetch(lod_depth_tex_solid, texel, 0).x;
 
-    // Fix Voxy translucents appearing in front of entities.
-#ifdef VOXY
-    float z_vanilla
-        = screen_to_view_space_depth(gbufferProjectionInverse, back_depth);
-    float z_lod = screen_to_view_space_depth(
-        lod_projection_matrix_inverse,
-        front_depth_lod
-    );
-    if (front_depth_lod < 1.0 && z_vanilla < z_lod
-        && front_depth == back_depth) {
-        translucent_color = vec4(0.0);
-    }
-#endif
-
     bool front_is_lod_terrain = is_lod_terrain(front_depth, front_depth_lod);
     bool back_is_lod_terrain = is_lod_terrain(back_depth, back_depth_lod);
 

--- a/shaders/program/voxy_translucent.glsl
+++ b/shaders/program/voxy_translucent.glsl
@@ -128,6 +128,13 @@ Material get_water_material(
 void voxy_emitFragment(VoxyFragmentParameters parameters) {
     vec2 coord = gl_FragCoord.xy * view_pixel_size * rcp(taau_render_scale);
 
+    // Discard if vanilla opaque geometry is in front of this fragment, so
+    // Voxy translucent doesn't paint over vanilla entities/glints in
+    // colortex13.
+    if (texelFetch(depthtex1, ivec2(gl_FragCoord.xy), 0).x < 1.0) {
+        discard;
+    }
+
     // Get the depth of the solid layer behind this fragment (used for edge
     // highlight effect)
 


### PR DESCRIPTION
Issue: Enchantment glints disappear or get covered by Voxy LoD chunks. Two root causes:

1. Voxy translucents render in front of glints in `colortex13`.
2. Glints disappear behind Voxy LoD chunks because the leak guard in `c1_blend_layers` (bdf6ae4, 7a3ce71) zeros `colortex13` at affected pixels.

Fix: Discarding Voxy translucent fragments where vanilla opaque is closer (0d91f02). The leak guard becomes redundant and is removed (9249b41). I could not find any case where this caused any regression.

| `colortex13` before | `colortex13` after commit 0d91f02 |
|---|---|
| <img width="2560" height="1529" alt="2026-06-01_21 44 38" src="https://github.com/user-attachments/assets/46d12bc9-9153-403f-b8ed-889a292b2e9c" /> | <img width="2560" height="1529" alt="2026-06-01_21 45 13" src="https://github.com/user-attachments/assets/47d2c417-755b-4082-8431-413a7abf2a43" /> |

### Final result

| before | after commit 9249b41 |
|---|---|
| <img width="2560" height="1529" alt="2026-06-01_21 43 33" src="https://github.com/user-attachments/assets/787c888c-da89-48b1-9ac1-54d689b43696" /> | <img width="2560" height="1529" alt="2026-06-01_21 45 38" src="https://github.com/user-attachments/assets/7ab6f70d-ee9e-4684-8764-53d6470f1f0f" /> |