### PR TITLE
Fix analytic fog in skymap with LOD mods

### DIFF
--- a/shaders/include/fog/overworld/analytic.glsl
+++ b/shaders/include/fog/overworld/analytic.glsl
@@ -35,7 +35,7 @@ mat2x3 air_fog_analytic(
     float skylight,
     float shadow
 ) {
-#ifdef LOD_MOD_ACTIVE
+#ifdef LOD_MOD_ACTIVE && !defined PROGRAM_DEFERRED0
     float fog_end = float(lod_render_distance);
 #else
     float fog_end = far;


### PR DESCRIPTION
Analytic fog caused the sky map to be completely white when LOD mods were enabled,


Reflections without voxy before
<img width="2560" height="1338" alt="voxy_before_reflection" src="https://github.com/user-attachments/assets/f08f29a2-7677-498b-8664-2325b4646072" />

Reflections with voxy after
<img width="2560" height="1338" alt="voxy_after_reflection" src="https://github.com/user-attachments/assets/cd55e881-5c9a-46f0-b88b-62a5fc991e1a" />


Lighting without voxy before
<img width="2560" height="1338" alt="lighting_voxy_off_before" src="https://github.com/user-attachments/assets/50c7739f-d485-4645-83d3-b3cd97740096" />

Lighting with voxy after before
<img width="2560" height="1338" alt="lighting_voxy_on-before" src="https://github.com/user-attachments/assets/a61590fe-3626-42a9-aa2a-0d738f6defb8" />

Lighting with voxy on after
<img width="2560" height="1338" alt="lighting_voxy_on_after" src="https://github.com/user-attachments/assets/bb9230d6-6d0e-41dd-8cd0-874fefbc0d04" />

Tested on a fresh instance on 1.21.11 with iris, sodium, voxy, and photon. No idea if this is limited to just this, but I did notice it here so