### PR TITLE
Fix skymap when using an LOD mod

### DIFF
--- a/shaders/program/d0_sky_map.fsh
+++ b/shaders/program/d0_sky_map.fsh
@@ -10,6 +10,7 @@
 */
 
 #include "/include/global.glsl"
+#undef LOD_MOD_ACTIVE
 
 layout(location = 0) out vec3 sky_map;
 


### PR DESCRIPTION
When using an LOD mod, the values stored in the skymap were wrong (at least partially due to analytic fog), this PR adds `#undef LOD_MOD_ACTIVE` at the top of d0_sky_map.fsh

Tested on a fresh instance on 1.21.11 with iris, sodium, voxy, and photon.


Reflections without voxy before
<img width="2560" height="1338" alt="voxy_before_reflection" src="https://github.com/user-attachments/assets/f08f29a2-7677-498b-8664-2325b4646072" />

Reflections with voxy after
<img width="2560" height="1338" alt="voxy_after_reflection" src="https://github.com/user-attachments/assets/cd55e881-5c9a-46f0-b88b-62a5fc991e1a" />


Lighting without voxy before
<img width="2560" height="1338" alt="lighting_voxy_off_before" src="https://github.com/user-attachments/assets/50c7739f-d485-4645-83d3-b3cd97740096" />

Lighting with voxy after
<img width="2560" height="1338" alt="lighting_voxy_on-before" src="https://github.com/user-attachments/assets/a61590fe-3626-42a9-aa2a-0d738f6defb8" />

Lighting with voxy on after
<img width="2560" height="1338" alt="lighting_voxy_on_after" src="https://github.com/user-attachments/assets/bb9230d6-6d0e-41dd-8cd0-874fefbc0d04" />