### PR TITLE
Fix rendering artifacts on distant glass for voxy mod

### DIFF
--- a/shaders/include/misc/lod_mod_support.glsl
+++ b/shaders/include/misc/lod_mod_support.glsl
@@ -39,6 +39,7 @@ uniform vec4 combined_projection_matrix_inverse_3;
 #define combined_depth_tex colortex15
 #define lod_depth_tex dhDepthTex
 #define lod_depth_tex_solid dhDepthTex1
+#define lod_depth_tex_shading lod_depth_tex
 #define lod_depth_tex_scale taau_render_scale
 #define lod_projection_matrix dhProjection
 #define lod_projection_matrix_inverse dhProjectionInverse
@@ -112,6 +113,7 @@ mat4 combined_projection_matrix_inverse = mat4(
 #define combined_depth_tex colortex15
 #define lod_depth_tex vxDepthTexTrans
 #define lod_depth_tex_solid vxDepthTexOpaque
+#define lod_depth_tex_shading lod_depth_tex_solid
 #define lod_depth_tex_scale 1.0
 #define lod_projection_matrix vxProj
 #define lod_projection_matrix_inverse vxProjInv

--- a/shaders/include/misc/raytracer.glsl
+++ b/shaders/include/misc/raytracer.glsl
@@ -6,7 +6,7 @@
 #include "/include/utility/space_conversion.glsl"
 
 #if defined SSRT_LOD
-#define SSRT_DEPTH_SAMPLER lod_depth_tex
+#define SSRT_DEPTH_SAMPLER lod_depth_tex_shading
 #define SSRT_PROJECTION_MATRIX lod_projection_matrix
 #define SSRT_PROJECTION_MATRIX_INVERSE lod_projection_matrix_inverse
 #else

--- a/shaders/program/d1_clouds.fsh
+++ b/shaders/program/d1_clouds.fsh
@@ -172,7 +172,8 @@ void main() {
 
     // LoD terrain support
 #ifdef LOD_MOD_ACTIVE
-    float depth_lod = depth_max_4x4(lod_depth_tex, lod_depth_tex_scale);
+    float depth_lod
+        = depth_max_4x4(lod_depth_tex_shading, lod_depth_tex_scale);
     bool is_lod = is_lod_terrain(depth_max, depth_lod);
 
     if (is_lod) {

--- a/shaders/program/d2_clouds_upscaling.fsh
+++ b/shaders/program/d2_clouds_upscaling.fsh
@@ -211,7 +211,7 @@ void main() {
 
 #ifdef LOD_MOD_ACTIVE
     // Check for LoD terrain
-    float depth_lod = texelFetch(lod_depth_tex, dst_texel, 0).x;
+    float depth_lod = texelFetch(lod_depth_tex_shading, dst_texel, 0).x;
     bool is_lod = is_lod_terrain(depth, depth_lod);
 
     float depth_linear

--- a/shaders/program/d3_ao.fsh
+++ b/shaders/program/d3_ao.fsh
@@ -108,7 +108,7 @@ void main() {
 
 #ifdef LOD_MOD_ACTIVE
     float depth_mc = texelFetch(depthtex1, view_texel, 0).x;
-    float depth_lod = texelFetch(lod_depth_tex, view_texel, 0).x;
+    float depth_lod = texelFetch(lod_depth_tex_shading, view_texel, 0).x;
     bool is_lod = is_lod_terrain(depth_mc, depth_lod);
 #else
 #define depth_mc depth

--- a/shaders/program/d4_deferred_shading.fsh
+++ b/shaders/program/d4_deferred_shading.fsh
@@ -215,7 +215,7 @@ void main() {
 
 #ifdef LOD_MOD_ACTIVE
     float depth_mc = texelFetch(depthtex1, texel, 0).x;
-    float depth_lod = texelFetch(lod_depth_tex, texel, 0).x;
+    float depth_lod = texelFetch(lod_depth_tex_shading, texel, 0).x;
     bool is_lod = is_lod_terrain(depth_mc, depth_lod);
 #else
     const bool is_lod = false;


### PR DESCRIPTION
The LOD shading changes in commit [a9dd45b](https://github.com/sixthsurge/photon/commit/03174486412bd6dd8e3be07dccbd1f069a9dd45b) switched cloud occlusion, combined-depth generation, AO, and deferred shading from `lod_depth_tex_solid` to `lod_depth_tex` to keep Distant Horizons shading in sync. 

In Voxy, these map to `vxDepthTexOpaque` and `vxDepthTexTrans`, causing opaque G-buffer data to be reconstructed using translucent glass depth. This produced severe artifacts and trails around distant glass structures when moving the camera, as reported in #606. Looks like:

<img width="50%" alt="1" src="https://github.com/user-attachments/assets/812c701e-9d90-4394-a712-9257be764ca8" />

You can see the video in #606 too.

This fix adds a shading-specific LOD depth selection. Distant Horizons continues using the front LOD depth, while Voxy uses its opaque depth for cloud occlusion, combined-depth generation, AO, deferred shading, and LOD screen-space ray tracing.

Tested in Minecraft 26.2 with Iris 1.11.2 on my own Minecraft server. It works well.