### PR TITLE
Backport selection overlays without separate draws

### DIFF
--- a/shaders/program/gbuffers_basic.fsh
+++ b/shaders/program/gbuffers_basic.fsh
@@ -82,7 +82,6 @@ void main() {
     }
 #endif
 
-#if defined IS_IRIS && defined USE_SEPARATE_ENTITY_DRAWS
     scene_color.rgb = srgb_eotf_inv(base_color.rgb) * rec709_to_working_color;
     // see note in function
     scene_color.a = fixup_translucent(tint.a);
@@ -90,7 +89,6 @@ void main() {
     if (renderStage == MC_RENDER_STAGE_OUTLINE) {
         scene_color.rgb *= 1.0 + BOX_EMISSION;
     }
-#endif
 
     vec2 encoded_normal = encode_unit_vector(normal);
 


### PR DESCRIPTION
## What

Backport 2fde442 from main so gbuffers_basic always writes scene color for selection outlines and other basic overlays.

## Why

The v1.3 maintenance branch intentionally disables separate entity programs on older Minecraft versions. The old compile guard also suppressed the basic-pass scene color in that configuration, making selection overlays such as Create glue disappear.

## Standalone compatibility

This is patch-identical to the fix already on Photon main. It does not enable separate entity draws or depend on patched Iris/Oculus; it only lets the existing basic pass write the color it already computes.

## Checks

- Stable patch ID matches main commit 2fde442 exactly
- git diff --check
- Runtime-tested by the reporter on the v1.3 maintenance fork
- Photon has no automated shader validator